### PR TITLE
Fix nav icon and update README

### DIFF
--- a/ui/README.adoc
+++ b/ui/README.adoc
@@ -11,7 +11,7 @@ npm run dev
 === Build
 Builds the UI into `/public` (to deploy to static sites)
 ```
-npm run build
+npm run build-preview
 ```
 
 === Bundle Antora Theme

--- a/ui/src/stylesheets/specific/navigation.scss
+++ b/ui/src/stylesheets/specific/navigation.scss
@@ -50,7 +50,7 @@
   height: var(--lg);
   width: var(--lg);
   left: calc(-1 * var(--lg) - var(--sm));
-  position: absolute;
+  position: relative;
 }
 
 .search > .input {


### PR DESCRIPTION
Nav Icons at sidebar has a misalignment with the corresponding text, and it was related to an absolute position of icon that was changed for a relative position.

Actual state:
<img width="167" alt="Captura de pantalla 2019-07-22 a la(s) 10 34 22" src="https://user-images.githubusercontent.com/33379285/61647039-14fec180-ac72-11e9-8517-7a306a0dcdda.png">

New state:
<img width="194" alt="Captura de pantalla 2019-07-22 a la(s) 10 34 28" src="https://user-images.githubusercontent.com/33379285/61647050-1fb95680-ac72-11e9-9820-9ce63dcf3167.png">

Also, README was changed because the build script was not up to date.