### PR TITLE
Add GSN intro guides

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,2 +1,4 @@
 .Gas Station Network
+* xref:gsn/getting-started.adoc[Getting started]
+* xref:gsn/what-is-the-gsn.adoc[What is the GSN?]
 * xref:gsn/faq.adoc[FAQ]

--- a/modules/ROOT/pages/gsn/getting-started.adoc
+++ b/modules/ROOT/pages/gsn/getting-started.adoc
@@ -4,21 +4,21 @@ The https://gsn.ethereum.org[Gas Station Network] (GSN for short) is a decentral
 
 The GSN was originally designed by Tabookey, and then further developed by OpenZeppelin. Today, it is backed by the Gas Station Network Alliance, a group of companies that adhere to and push the GSN standard.
 
-The OpenZeppelin Platform provides full GSN support across the entire stack, so you can easily start developing a GSN-capable application. But before going through the components below, make sure you go check out our GSN introductory guide.
+The OpenZeppelin Platform provides full GSN support across the entire stack, so you can easily start developing a GSN-capable application. But before going through the components below, make sure you go check out our xref:what-is-the-gsn.adoc[GSN introductory guide].
 
 == Contracts
 
 OpenZeppelin Contracts provides the base utilities to make your contracts GSN-capable, by allowing them to receive meta-transactions using the GSN standard, and providing some payment strategies out of the box.
 
-* Learn how to write a GSN-capable contract
-* Check out the pre-built payment strategies
-* Read the API reference for the `GSNRecipient` base contract
+* Learn https://docs.openzeppelin.com/contracts/2.x/gsn[how to write a GSN-capable contract]
+* Check out the https://docs.openzeppelin.com/contracts/2.x/gsn-advanced[pre-built payment strategies]
+* Read https://docs.openzeppelin.com/contracts/2.x/api/gsn[the API reference for the GSN contracts]
 
 == SDK
 
 The OpenZeppelin CLI can be used to compile and manage your GSN-capable contracts. In addition, we have built a set of GSN-specific helpers to make local development simple, and a front-end library so applications can easily send meta-transactions via the GSN.
 
-* Learn how to build a GSN-powered dapp from scratch in React
+* Learn how to https://docs.openzeppelin.com/sdk/2.5/gsn-dapp[build a GSN-powered dapp from scratch] in React
 * Check out the https://github.com/OpenZeppelin/openzeppelin-network.js[repo for `@openzeppelin/network.js`] for easily setting up a GSN-ready web3 instance
 * Check out the https://github.com/OpenZeppelin/openzeppelin-gsn-provider[repo for `@openzeppelin/gsn-provider`] for more info on the web3 GSN-enabled provider
 * Check out the https://github.com/OpenZeppelin/openzeppelin-gsn-helpers[repo for `@openzeppelin/gsn-helpers`] to see how to set up a working GSN in your local network with a single command
@@ -27,6 +27,6 @@ The OpenZeppelin CLI can be used to compile and manage your GSN-capable contract
 
 The preconfigured OpenZeppelin Starter Kits are an easy way to learn and bootstrap your dapps. We have added a new GSN Starter Kit that ships with full GSN support, and a small demo to understand how the pieces fit together.
 
-* Read about the GSN Starter Kit in the docs
+* Read about the https://docs.openzeppelin.com/starter-kits/2.3/gsnkit[GSN Starter Kit] in the docs
 * Check out the https://github.com/OpenZeppelin/starter-kit-gsn[`openzeppelin/starter-kit-gsn` repo] to see the code
 * Unpack the kit by running `openzeppelin unpack @openzeppelin/starter-kit-gsn` to try it out right away

--- a/modules/ROOT/pages/gsn/getting-started.adoc
+++ b/modules/ROOT/pages/gsn/getting-started.adoc
@@ -1,0 +1,32 @@
+= Getting started with the Gas Station Network
+
+The https://gsn.ethereum.org[Gas Station Network] (GSN for short) is a decentralized solution for solving user onboarding to Ethereum applications. It allows dapps to pay for their users' transactions in a secure way, so users don't need to hold ETH to pay for their gas, and don't even need to set up an account.
+
+The GSN was originally designed by Tabookey, and then further developed by OpenZeppelin. Today, it is backed by the Gas Station Network Alliance, a group of companies that adhere to and push the GSN standard.
+
+The OpenZeppelin Platform provides full GSN support across the entire stack, so you can easily start developing a GSN-capable application. But before going through the components below, make sure you go check out our GSN introductory guide.
+
+== Contracts
+
+OpenZeppelin Contracts provides the base utilities to make your contracts GSN-capable, by allowing them to receive meta-transactions using the GSN standard, and providing some payment strategies out of the box.
+
+* Learn how to write a GSN-capable contract
+* Check out the pre-built payment strategies
+* Read the API reference for the `GSNRecipient` base contract
+
+== SDK
+
+The OpenZeppelin CLI can be used to compile and manage your GSN-capable contracts. In addition, we have built a set of GSN-specific helpers to make local development easier, and a front-end library so applications can easily send meta-transactions via the GSN.
+
+* Learn how to build a GSN-powered dapp from scratch in React
+* Check out the repo for `@openzeppelin/network.js` for easily setting up a GSN-ready web3 instance
+* Check out the repo for `@openzeppelin/gsn-provider` for more info on the web3 GSN-enabled provider
+* Check out the repo for `@openzeppelin/gsn-helpers` to see how to set up a working GSN in your local network with a single command
+
+== Starter kit
+
+The preconfigured OpenZeppelin Starter Kits are an easy way to learn and bootstrap your dapps. We have added a new GSN Starter Kit that ships with full GSN support, and a small demo to understand how the pieces fit together.
+
+* Read about the GSN Starter Kit in the docs
+* Check out the repo for `@openzeppelin/starter-kit-gsn` to see the code
+* Unpack the kit by running `openzeppelin unpack @openzeppelin/starter-kit-gsn` to try it out right away

--- a/modules/ROOT/pages/gsn/getting-started.adoc
+++ b/modules/ROOT/pages/gsn/getting-started.adoc
@@ -1,6 +1,6 @@
 = Getting started with the Gas Station Network
 
-The https://gsn.ethereum.org[Gas Station Network] (GSN for short) is a decentralized solution for solving user onboarding to Ethereum applications. It allows dapps to pay for their users' transactions in a secure way, so users don't need to hold ETH to pay for their gas, and don't even need to set up an account.
+The https://gsn.ethereum.org[Gas Station Network] (GSN for short) is a decentralized solution for solving user onboarding to Ethereum applications. It allows dapps to pay for their users' transactions in a secure way, so users don't need to hold ETH to pay for their gas or even set up an account.
 
 The GSN was originally designed by Tabookey, and then further developed by OpenZeppelin. Today, it is backed by the Gas Station Network Alliance, a group of companies that adhere to and push the GSN standard.
 
@@ -16,7 +16,7 @@ OpenZeppelin Contracts provides the base utilities to make your contracts GSN-ca
 
 == SDK
 
-The OpenZeppelin CLI can be used to compile and manage your GSN-capable contracts. In addition, we have built a set of GSN-specific helpers to make local development easier, and a front-end library so applications can easily send meta-transactions via the GSN.
+The OpenZeppelin CLI can be used to compile and manage your GSN-capable contracts. In addition, we have built a set of GSN-specific helpers to make local development simple, and a front-end library so applications can easily send meta-transactions via the GSN.
 
 * Learn how to build a GSN-powered dapp from scratch in React
 * Check out the https://github.com/OpenZeppelin/openzeppelin-network.js[repo for `@openzeppelin/network.js`] for easily setting up a GSN-ready web3 instance

--- a/modules/ROOT/pages/gsn/getting-started.adoc
+++ b/modules/ROOT/pages/gsn/getting-started.adoc
@@ -19,14 +19,14 @@ OpenZeppelin Contracts provides the base utilities to make your contracts GSN-ca
 The OpenZeppelin CLI can be used to compile and manage your GSN-capable contracts. In addition, we have built a set of GSN-specific helpers to make local development easier, and a front-end library so applications can easily send meta-transactions via the GSN.
 
 * Learn how to build a GSN-powered dapp from scratch in React
-* Check out the repo for `@openzeppelin/network.js` for easily setting up a GSN-ready web3 instance
-* Check out the repo for `@openzeppelin/gsn-provider` for more info on the web3 GSN-enabled provider
-* Check out the repo for `@openzeppelin/gsn-helpers` to see how to set up a working GSN in your local network with a single command
+* Check out the https://github.com/OpenZeppelin/openzeppelin-network.js[repo for `@openzeppelin/network.js`] for easily setting up a GSN-ready web3 instance
+* Check out the https://github.com/OpenZeppelin/openzeppelin-gsn-provider[repo for `@openzeppelin/gsn-provider`] for more info on the web3 GSN-enabled provider
+* Check out the https://github.com/OpenZeppelin/openzeppelin-gsn-helpers[repo for `@openzeppelin/gsn-helpers`] to see how to set up a working GSN in your local network with a single command
 
 == Starter kit
 
 The preconfigured OpenZeppelin Starter Kits are an easy way to learn and bootstrap your dapps. We have added a new GSN Starter Kit that ships with full GSN support, and a small demo to understand how the pieces fit together.
 
 * Read about the GSN Starter Kit in the docs
-* Check out the repo for `@openzeppelin/starter-kit-gsn` to see the code
+* Check out the https://github.com/OpenZeppelin/starter-kit-gsn[`openzeppelin/starter-kit-gsn` repo] to see the code
 * Unpack the kit by running `openzeppelin unpack @openzeppelin/starter-kit-gsn` to try it out right away

--- a/modules/ROOT/pages/gsn/getting-started.adoc
+++ b/modules/ROOT/pages/gsn/getting-started.adoc
@@ -1,6 +1,6 @@
 = Getting started with the Gas Station Network
 
-The https://gsn.ethereum.org[Gas Station Network] (GSN for short) is a decentralized solution for solving user onboarding to Ethereum applications. It allows dapps to pay for their users' transactions in a secure way, so users don't need to hold ETH to pay for their gas or even set up an account.
+The https://gsn.ethereum.org[Gas Station Network] (GSN for short) is a decentralized solution for solving user onboarding to Ethereum applications. It allows dapps to pay for their users' transactions in a secure way, so *users don't need to hold ETH to pay for their gas* or even set up an account.
 
 The GSN was originally designed by Tabookey, and then further developed by OpenZeppelin. Today, it is backed by the Gas Station Network Alliance, a group of companies that adhere to and push the GSN standard.
 

--- a/modules/ROOT/pages/gsn/what-is-the-gsn.adoc
+++ b/modules/ROOT/pages/gsn/what-is-the-gsn.adoc
@@ -3,11 +3,11 @@
 *https://gsn.openzeppelin.com[Website]*
 
 User onboarding is one of the hottest topics in Ethereum. UI/UX along with scalability have been identified as the main problems that prevent adoption. Meta-transactions are a key component to improve the user experience.
-Here you'll learn about what the Gas Station Network (GSN) is and how it solves this problem, by allowing users of a contract to send transactions without needing Ether to pay for gas.
+Here you'll learn what the Gas Station Network (GSN) is and how it solves this problem, by allowing users of a contract to send transactions without needing Ether to pay for gas.
 
 == Sending gas-less transactions
 
-All Ethereum transactions use gas, and the sender of each transaction must have enough Ether to pay for the gas spent. Even though these gas costs are low for basic transactions (a couple of cents), getting this Ether is no easy task: dApp users often need to go through Know Your Customer and Anti Money-Laundering processes (KYC & AML), which not only takes time but often involves sending a selfie holding their passport over the Internet (!).
+All Ethereum transactions use gas, and the sender of each transaction must have enough Ether to pay for the gas spent. Even though these gas costs are low for basic transactions (a couple of cents), getting Ether is no easy task: dApp users often need to go through Know Your Customer and Anti Money-Laundering processes (KYC & AML), which not only takes time but often involves sending a selfie holding their passport over the Internet (!).
 On top of that, they also need to provide financial information to be able to purchase Ether through an exchange.
 Only the most hardcore users will put up with this hassle, and dApp adoption greatly suffers when Ether is required. We can do better.
 
@@ -35,7 +35,7 @@ One of RelayHub's jobs is to act as a, well, _hub_ for all relayers: they will a
 
 The other key task RelayHub carries out is the actual _relaying of transactions_, the sole purpose behind this whole system. Instead of calling a function in your contract directly, your users will request a relayer to do it for them, who will then execute RelayHub's relayCall function. RelayHub will verify that the transaction is legitimate (protecting both users and recipients from dishonest relayers), and then call into your contract as originally requested by your user. This requires your recipient trusting RelayHub to do the right thing, but since it is a smart contract, this is as simple as reading its source code!
 
-NOTE: The RelayHub address will be the same in each network. Right now, the latest relay hub is live with this address `0xD216153c06E857cD7f72665E0aF1d7D82172F494`.
+NOTE: The RelayHub address will be the same in each network. Right now, the latest relay hub is live at this address: https://etherscan.io/address/0xD216153c06E857cD7f72665E0aF1d7D82172F494[`0xD216153c06E857cD7f72665E0aF1d7D82172F494`].
 
 == Receiving a relayed call
 
@@ -63,6 +63,7 @@ To recap, there are four main actors in the GSN:
 == Further reading
 
 * The https://medium.com/@rrecuero/eth-onboarding-solution-90607fb81380[GSN announcement post] provides a good *overview of the system*, along with some use cases to take inspiration from.
-* If you want to learn how to use *OpenZeppelin Contract's pre-made accept and charge strategies*, we'll add an advanced GSN recipients guide soon.
+* To learn how to use OpenZeppelin Contracts to *build a GSN-capable contract*, head to the https://docs.openzeppelin.com/contracts/2.x/gsn[GSN basics guide].
+* If you want to learn how to use OpenZeppelin Contracts' *pre-made accept and charge strategies*, we'll add an advanced GSN recipients guide soon.
 * If instead you wish to know more about how to *use GSN from your application*, head to the https://github.com/OpenZeppelin/openzeppelin-gsn-provider[OpenZeppelin GSN provider guides].
 * For information on how to *test GSN-enabled contracts*, go to the https://github.com/OpenZeppelin/openzeppelin-gsn-helpers[OpenZeppelin test helpers documentation].

--- a/modules/ROOT/pages/gsn/what-is-the-gsn.adoc
+++ b/modules/ROOT/pages/gsn/what-is-the-gsn.adoc
@@ -1,9 +1,7 @@
 = What is the Gas Station Network?
 
-*https://gsn.openzeppelin.com[Website]*
-
 User onboarding is one of the hottest topics in Ethereum. UI/UX along with scalability have been identified as the main problems that prevent adoption. Meta-transactions are a key component to improve the user experience.
-Here you'll learn what the Gas Station Network (GSN) is and how it solves this problem, by allowing users of a contract to send transactions without needing Ether to pay for gas.
+Here you'll learn what the https://gsn.openzeppelin.com[Gas Station Network] (GSN) is and https://blog.openzeppelin.com/gsn-the-ultimate-ethereum-onboarding-solution/[how it solves this problem], by allowing users of a contract to send transactions without needing Ether to pay for gas.
 
 == Sending gas-less transactions
 
@@ -47,7 +45,7 @@ The OpenZeppelin Contracts package includes a number of utilities to make receiv
 
 By now you may be wondering how exactly relayers charge their recipients for gas costs and service fees. The answer is simple: each recipient must have funds deposited on RelayHub in advance, and payment is automatically handled on each relayed call.
 
-You can head to the https://gsn.openzeppelin.com/recipients[GSN Recipient Tool] to check and top-up your contracts' balance, view previous charges, or do all of this programatically by calling `IRelayHub.depositFor` and `IRelayHub.balanceOf`.
+You can head to the https://gsn.openzeppelin.com/recipients[GSN Recipient Tool] to check and top-up your contracts' balance, view previous charges, or do all of this programatically using the https://github.com/OpenZeppelin/openzeppelin-gsn-helpers[`oz-gsn` command line tool].
 
 Recipients may withdraw their balance from the system at any point, but remember that they will not be able to receive any further relayed calls!
 

--- a/modules/ROOT/pages/gsn/what-is-the-gsn.adoc
+++ b/modules/ROOT/pages/gsn/what-is-the-gsn.adoc
@@ -1,0 +1,68 @@
+= What is the Gas Station Network?
+
+*https://gsn.openzeppelin.com[Website]*
+
+User onboarding is one of the hottest topics in Ethereum. UI/UX along with scalability have been identified as the main problems that prevent adoption. Meta-transactions are a key component to improve the user experience.
+Here you'll learn about what the Gas Station Network (GSN) is and how it solves this problem, by allowing users of a contract to send transactions without needing Ether to pay for gas.
+
+== Sending gas-less transactions
+
+All Ethereum transactions use gas, and the sender of each transaction must have enough Ether to pay for the gas spent. Even though these gas costs are low for basic transactions (a couple of cents), getting this Ether is no easy task: dApp users often need to go through Know Your Customer and Anti Money-Laundering processes (KYC & AML), which not only takes time but often involves sending a selfie holding their passport over the Internet (!).
+On top of that, they also need to provide financial information to be able to purchase Ether through an exchange.
+Only the most hardcore users will put up with this hassle, and dApp adoption greatly suffers when Ether is required. We can do better.
+
+**Enter meta-transactions**. This is a fancy name for a simple idea: a third-party can send another user's transactions and pay themselves for the gas cost. That's it! There's some tricky technical details, but those can be safely ignored when interacting with the GSN. This way, instead of your users calling into your contract (called the _recipient_) directly, someone else (we'll call them a _relayer_) will send their transaction and pay for the cost.
+
+But why would they do such a thing?
+
+== Incentives
+
+Relayers are not running a charity: they're running a business. The reason why they'll gladly pay for your users' gas costs is because they will in turn charge your contract, the recipient. That way relayers get their money back, plus a bit extra as a _fee_ for their services.
+
+This may sound strange at first, but paying for user onboarding is a very common business practice. Lots of money is spent on advertising, free trials, new user discounts, etc., all with the https://en.wikipedia.org/wiki/Customer_acquisition_cost[goal of user acquisition]. Compared to those, the cost of a couple of Ethereum transactions is actually very small.
+
+Additionally, you can leverage the GSN in scenarios where your users pay you off-chain in advance (e.g. via credit card), with each GSN-call deducting from their balance on your system. The possibilities are endless!
+
+=== Should I trust these relayers?
+
+You don't need to! The GSN is set up in such a way where it's in the relayers' best interest to serve your requests, and there are measures in place to penalize them if they misbehave. All of this happens automatically, so you can safely start using their services worry-free.
+
+== One contract to coordinate them all
+
+There are many meta-transaction implementations out there, but the GSN has a unique detail that makes it special. Inside its core, a smart contract is responsible for keeping track of relayers, handling relayed transactions, charging their recipients, and generally ensuring all parties stay honest. This contract is called RelayHub, and there is a _single_ instance of it in the whole network (you don't need to deploy your own!). Think of it as a piece of public infrastructure, for all Ethereum users to benefit from.
+
+One of RelayHub's jobs is to act as a, well, _hub_ for all relayers: they will advertise their services on this contract, and your users will query it to find the relayer that best suits their purposes. This is out of scope for this guide however, and is not something you need to worry about when writing a recipient contract. If you want to learn more about sending transactions via relayers, head to our https://github.com/OpenZeppelin/openzeppelin-gsn-provider[GSNProvider guide].
+
+The other key task RelayHub carries out is the actual _relaying of transactions_, the sole purpose behind this whole system. Instead of calling a function in your contract directly, your users will request a relayer to do it for them, who will then execute RelayHub's relayCall function. RelayHub will verify that the transaction is legitimate (protecting both users and recipients from dishonest relayers), and then call into your contract as originally requested by your user. This requires your recipient trusting RelayHub to do the right thing, but since it is a smart contract, this is as simple as reading its source code!
+
+NOTE: The RelayHub address will be the same in each network. Right now, the latest relay hub is live with this address `0xD216153c06E857cD7f72665E0aF1d7D82172F494`.
+
+== Receiving a relayed call
+
+We've mentioned how the RelayHub, and not your user, is the one that actually ends up calling a function in your contract. We will refer to this as the _relayed call_. Your contract needs to be set up to accept relayed calls from the hub. In particular, it needs to be able to answer whether it will pay for a given relayed call, and run some bookeeping to make sure a malicious user cannot abuse it. It also needs to unwrap a relayed call in order to process it.
+
+The OpenZeppelin Contracts package includes a number of utilities to make receiving relayed calls as easy as developing a regular Solidity contract, without needing to worry about the low level details. It also ships with two built-in strategies for managing relayed call subsidies.
+
+== Payment
+
+By now you may be wondering how exactly relayers charge their recipients for gas costs and service fees. The answer is simple: each recipient must have funds deposited on RelayHub in advance, and payment is automatically handled on each relayed call.
+
+You can head to the https://gsn.openzeppelin.com/recipients[GSN Recipient Tool] to check and top-up your contracts' balance, view previous charges, or do all of this programatically by calling `IRelayHub.depositFor` and `IRelayHub.balanceOf`.
+
+Recipients may withdraw their balance from the system at any point, but remember that they will not be able to receive any further relayed calls!
+
+== Summing up
+
+To recap, there are four main actors in the GSN:
+
+- A singleton *RelayHub* contract, that coordinates the entire network. All relayed transactions need to go through it, and all relayer stakes and recipients funds are held by it.
+- A decentralized set of *Relayers*. A relayer must register itself on the RelayHub by staking funds, as the hub penalizes it if it misbehaves.
+- A set of *Recipients*, which are the dapp contracts that pay for their users' transactions. Recipients need to deposit funds on the hub in order to pay for the relayed calls, and need to adhere to a specific interface to accept the meta transactions.
+- The end *Users* of the recipient contracts. Instead of sending regular Ethereum transactions, these users can just sign a transaction with any key, and send it off-chain to a Relayer to be sent to the network.
+
+== Further reading
+
+* The https://medium.com/@rrecuero/eth-onboarding-solution-90607fb81380[GSN announcement post] provides a good *overview of the system*, along with some use cases to take inspiration from.
+* If you want to learn how to use *OpenZeppelin Contract's pre-made accept and charge strategies*, we'll add an advanced GSN recipients guide soon.
+* If instead you wish to know more about how to *use GSN from your application*, head to the https://github.com/OpenZeppelin/openzeppelin-gsn-provider[OpenZeppelin GSN provider guides].
+* For information on how to *test GSN-enabled contracts*, go to the https://github.com/OpenZeppelin/openzeppelin-gsn-helpers[OpenZeppelin test helpers documentation].


### PR DESCRIPTION
Adds two new guides:
- A getting started with links to other sections and repos
- A what-is-the-gsn guide, extracted from the basic contracts guide