### PR TITLE
Leave default outline on :focus

### DIFF
--- a/ui/src/stylesheets/globals/_reset.scss
+++ b/ui/src/stylesheets/globals/_reset.scss
@@ -122,10 +122,6 @@ button {
   background: transparent;
   box-shadow: none;
   overflow: visible;
-
-  &:focus {
-    outline: 0;
-  }
 }
 
 button,
@@ -167,10 +163,6 @@ textarea {
   -webkit-appearance: none;
   background: transparent;
   border: 0;
-
-  &:focus {
-    outline: none;
-  }
 
   &[type='radio'] {
     -webkit-appearance: radio;
@@ -259,9 +251,4 @@ input[type='search'] {
   &::-webkit-search-results-decoration {
     display: none;
   }
-}
-
-select:focus,
-a:focus {
-  outline: 0;
 }

--- a/ui/src/stylesheets/globals/_typography.scss
+++ b/ui/src/stylesheets/globals/_typography.scss
@@ -197,16 +197,3 @@ dd {
 .strikethrough {
   text-decoration: line-through;
 }
-
-// .link {
-//   color: var(--steel-2);
-//
-//   &:hover {
-//     color: var(--violet-2);
-//   }
-//
-//   &:focus,
-//   &:active {
-//     color: var(--core-violet-3);
-//   }
-// }


### PR DESCRIPTION
Outlines on `:focus` are needed for accessibility. See http://www.outlinenone.com.