### PR TITLE
Add more sources to playbook

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -8,14 +8,37 @@ content:
   sources:
     - url: .
       branches: HEAD
+
     - url: https://github.com/OpenZeppelin/openzeppelin-contracts
-      branches: docs-v2.x
+      branches: docs-v*
       start_path: docs
+
     - url: https://github.com/OpenZeppelin/openzeppelin-sdk
       branches: release-docs/*
       start_path: packages/docs
+
     - url: https://github.com/OpenZeppelin/starter-kit
-      branches: master
+      branches: master # Starter Kit is unversioned
+      start_path: docs
+
+    - url: https://github.com/OpenZeppelin/openzeppelin-test-environment
+      branches: docs-v*
+      start_path: docs
+
+    - url: https://github.com/OpenZeppelin/openzeppelin-test-helpers
+      branches: docs-v*
+      start_path: docs
+
+    - url: https://github.com/OpenZeppelin/openzeppelin-gsn-provider
+      branches: docs-v*
+      start_path: docs
+
+    - url: https://github.com/OpenZeppelin/openzeppelin-gsn-helpers
+      branches: docs-v*
+      start_path: docs
+
+    - url: https://github.com/OpenZeppelin/openzeppelin-network.js
+      branches: docs-v*
       start_path: docs
 ui:
   bundle:

--- a/ui/src/partials/navigation.hbs
+++ b/ui/src/partials/navigation.hbs
@@ -6,7 +6,7 @@
   </div>
 
   <div class="nav-components">
-    {{#sorted site.components "openzeppelin, contracts, sdk, starter-kit"}}
+    {{#sorted site.components "openzeppelin, contracts, sdk, starter-kits, test-environment, test-helpers, network.js, gsn-provider, gsn-helpers"}}
     <div class="nav-component {{#if (eq this @root.page.component)}}nav-component-active{{/if}}">
       <div
         class="flex align-center justify-justified nav-heading nav-component-heading {{#if (eq this @root.page.component)}}nav-heading-active{{/if}}">


### PR DESCRIPTION
Part of #47 

This adds all sources that have been migrated to the docsite setup into a temporary branch. The idea is for this to serve as a staging environment to fix styles, etc., before merging to `master`.