### PR TITLE
Remove leading underscore on ids

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -9,11 +9,11 @@ content:
     - url: .
       branches: HEAD
       start_path: components/home
-    
+
     - url: .
       branches: HEAD
       start_path: components/learn
-    
+
     - url: https://github.com/OpenZeppelin/openzeppelin-contracts
       branches: docs-v*
       start_path: docs
@@ -54,3 +54,6 @@ ui:
     url: ./ui/build/oz-docs-ui.zip
     # url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable
     # snapshot: true
+asciidoc:
+  attributes:
+    idprefix: ''


### PR DESCRIPTION
While we have manual ids for most of our sections (so that we can change the titles and not break links), it makes sense for the autogenerated ones to:

a) not be ugly
b) be reasonable

This is specially useful for the API references.

See the following caveat from the asciidoctor docs:
> If you set the idprefix to blank, you could end up generating IDs that are invalid in DocBook output (e.g., an ID that begins with a number) or that match a built-in ID in the HTML output (e.g., header). In this case, we recommend either using a non-empty value of idprefix or assigning explicit IDs to your sections. 