### PR TITLE
Add intall instruction for cli

### DIFF
--- a/components/learn/modules/ROOT/pages/setting-up-a-node-project.adoc
+++ b/components/learn/modules/ROOT/pages/setting-up-a-node-project.adoc
@@ -45,6 +45,7 @@ Some OpenZeppelin tools (like the xref:cli::index.adoc[CLI]) are executables int
 ```console
 $ openzeppelin init
 openzeppelin: command not found
+$ npm install --global @openzeppelin/cli
 $ npx openzeppelin init
 Welcome to the OpenZeppelin SDK!
 ```


### PR DESCRIPTION
In order to run the `openzeppelin init` you first need to install the cli.