### PR TITLE
Update upgrading-smart-contracts.adoc to CLI 2.7

### DIFF
--- a/components/learn/modules/ROOT/pages/upgrading-smart-contracts.adoc
+++ b/components/learn/modules/ROOT/pages/upgrading-smart-contracts.adoc
@@ -167,7 +167,7 @@ NOTE: You can check out a full version of the code in this section in the https:
 All our code from now on will be part of the `main` function. Let's begin by creating a new `project`, to manage our upgradeable contracts.
 
 ```js
-const [from] = await ZWeb3.accounts();
+const [from] = await ZWeb3.eth.getAccounts();
 const project = new ProxyAdminProject('MyProject', null, null, { from, gas: 1e6, gasPrice: 1e9 });
 ```
 


### PR DESCRIPTION
Raised in the forum by a community member: 
https://forum.openzeppelin.com/t/typeerror-zweb3-accounts-is-not-a-function/2343

ZWeb3 was changed in OpenZeppelin CLI 2.7
>https://github.com/OpenZeppelin/openzeppelin-sdk/releases/tag/v2.7.0
>Trimmed the API of the ZWeb3 object to remove methods duplicated from web3.js. (https://github.com/OpenZeppelin/openzeppelin-sdk/pull/1369)