### PR TITLE
Update footer copyright to 2020

### DIFF
--- a/ui/src/partials/footer.hbs
+++ b/ui/src/partials/footer.hbs
@@ -1,6 +1,6 @@
 <footer class="footer">
 	<div class="rights">
-		<span>© OpenZeppelin 2017-2019 </span>
+		<span>© OpenZeppelin 2017-2020 </span>
 		<a class="terms" href="https://openzeppelin.com/privacy">Privacy</a>
 		<a class="terms" href="https://openzeppelin.com/tos">Terms of Use</a>
 	</div>


### PR DESCRIPTION
Currently footer shows and should be updated to 2020
>© OpenZeppelin 2017-2019 Privacy Terms of Use