### PR TITLE
Fix 'latest' redirects 

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "glob": "^7.1.4",
     "js-yaml": "^3.13.1",
     "multimatch": "^4.0.0",
+    "semver": "^7.1.3",
     "yarn": "^1.19.1"
   },
   "license": "MIT",

--- a/scripts/latest-redirects.js
+++ b/scripts/latest-redirects.js
@@ -20,6 +20,8 @@ for (const comp of components) {
     .map(c => c.replace(/\/$/, ''))
     // Remove anything that doesn't look like a version.
     .filter(c => sv.coerce(c) !== null)
+    // Remove prereleases: these will have a dash, e.g. '3.x-rc.0'
+    .filter(c => c.indexOf('-') === -1)
     // Sort from latest to oldest. Coerces each version into a valid semver
     // version because some component versions might be '2.x'.
     .sort((a, b) => sv.rcompare(sv.coerce(a), sv.coerce(b)));

--- a/scripts/latest-redirects.js
+++ b/scripts/latest-redirects.js
@@ -21,7 +21,7 @@ for (const comp of components) {
     // Remove anything that doesn't look like a version.
     .filter(c => sv.coerce(c) !== null)
     // Remove prereleases: these will have a dash, e.g. '3.x-rc.0'
-    .filter(c => c.indexOf('-') === -1)
+    .filter(c => !c.includes('-'))
     // Sort from latest to oldest. Coerces each version into a valid semver
     // version because some component versions might be '2.x'.
     .sort((a, b) => sv.rcompare(sv.coerce(a), sv.coerce(b)));

--- a/yarn.lock
+++ b/yarn.lock
@@ -8503,6 +8503,11 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
+  integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==
+
 semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"


### PR DESCRIPTION
This removes prereleases when considering 'latest' redirects, imitating [Antora's behavior](https://docs.antora.org/antora/2.2/component-versions/#latest-version).

I also added `semver` as an explicit dependency: we were previously relying on it being included by some other dependency.