### PR TITLE
Move projects to maintenance only

### DIFF
--- a/components/home/modules/ROOT/pages/index.adoc
+++ b/components/home/modules/ROOT/pages/index.adoc
@@ -30,11 +30,15 @@ xref:contracts::index.adoc[[.card-title]#Contracts# [.card-body]#A library of mo
 xref:cli::index.adoc[[.card-title]#CLI# [.card-body]#A command-line tool to help you deploy+++,+++ upgrade+++,+++ and interact with your smart contracts.# [.card-cta]#Get started >#]
 --
 
-[.card.card-primary.card-starter-kits]
+[.card.card-primary.card-test-helpers]
 --
-xref:starter-kits::index.adoc[[.card-title]#Starter Kits# [.card-body]#Bundles to bootstrap your decentralized web application.# [.card-cta]#Get started >#]
+xref:test-helpers::index.adoc[[.card-title]#Test Helpers# [.card-body]#A JavaScript library of common assertions for smart contracts+++,+++ which can be used with test-environment+++,+++ truffle+++,+++ or vanilla web3-js setups.#]
 --
 
+[.card.card-secondary.card-contract-loader]
+--
+xref:contract-loader::index.adoc[[.card-title]#Contract Loader# [.card-body]#A minimal JavaScript library for loading contract artifacts by name or ABI.#]
+--
 
 [.card.card-secondary.card-upgrades-js]
 --
@@ -46,34 +50,9 @@ xref:upgrades::index.adoc[[.card-title]#Upgrades# [.card-body]#A JavaScript libr
 xref:test-environment::index.adoc[[.card-title]#Test Environment# [.card-body]#A JavaScript library for creating a testing environment for contracts+++,+++ which plays nice with Mocha+++,+++ Ava+++,+++ and Jest.#]
 --
 
-[.card.card-secondary.card-test-helpers]
---
-xref:test-helpers::index.adoc[[.card-title]#Test Helpers# [.card-body]#A JavaScript library of common assertions for smart contracts+++,+++ which can be used with `test-environment`+++,+++ `truffle`+++,+++ or vanilla `web3-js` setups.#]
---
-
-[.card.card-secondary.card-network-js]
---
-xref:network-js::index.adoc[[.card-title]#Network JS# [.card-body]#A JavaScript library for easily connecting to the Ethereum network from a dapp+++,+++ used in most Starter Kits.#]
---
-
-[.card.card-secondary.card-gsn-helpers]
---
-xref:gsn-helpers::index.adoc[[.card-title]#GSN Helpers# [.card-body]#A thin CLI and JavaScript library for simplifying development of an application using the Gas Station Network.#]
---
-
-[.card.card-secondary.card-gsn-provider]
---
-xref:gsn-provider::index.adoc[[.card-title]#GSN Provider# [.card-body]#A `web3-js` provider for seamlessly sending gasless transactions via the Gas Station Network.#]
---
-
 [.card.card-secondary.card-contract-loader]
 --
 https://github.com/OpenZeppelin/solidity-loader[[.card-title]#Hot Loader# [.card-body]#A webpack plugin for automatically compiling and upgrading your contracts locally while you develop.#]
---
-
-[.card.card-secondary.card-contract-loader]
---
-xref:contract-loader::index.adoc[[.card-title]#Contract Loader# [.card-body]#A minimal JavaScript library for loading contract artifacts by name or ABI.#]
 --
 
 [.card.card-secondary.card-solidity-docgen]

--- a/components/learn/modules/ROOT/nav.adoc
+++ b/components/learn/modules/ROOT/nav.adoc
@@ -5,6 +5,4 @@
 * xref:writing-automated-tests.adoc[Writing Automated Tests]
 * xref:connecting-to-public-test-networks.adoc[Connecting to Public Test Networks]
 * xref:upgrading-smart-contracts.adoc[Upgrading Smart Contracts]
-* xref:sending-gasless-transactions.adoc[Sending Gasless Transactions]
-* xref:building-a-dapp.adoc[Building a Dapp]
 * xref:preparing-for-mainnet.adoc[Preparing for Mainnet]

--- a/components/learn/modules/ROOT/partials/cards.adoc
+++ b/components/learn/modules/ROOT/partials/cards.adoc
@@ -30,15 +30,5 @@ xref:learn::connecting-to-public-test-networks.adoc[[.card-title]#Connecting to 
 
 [.card.card-learn]
 --
-xref:learn::building-a-dapp.adoc[[.card-title]#Building a Dapp# [.card-body]#Create a decentralized web app using OpenZeppelin Network JS and Hot Loader, or simply unpack a Starter Kit.#]
---
-
-[.card.card-learn]
---
-xref:learn::sending-gasless-transactions.adoc[[.card-title]#Sending Gasless Transactions# [.card-body]#Leverage the Gas Station Network so your users can send transactions without having ETH to pay for gas.#]
---
-
-[.card.card-learn]
---
 xref:learn::preparing-for-mainnet.adoc[[.card-title]#Preparing for Mainnet# [.card-body]#All the boxes you need to check before taking your project to production on the main Ethereum network.#]
 --

--- a/ui/preview-src/ui-model.yml
+++ b/ui/preview-src/ui-model.yml
@@ -89,6 +89,7 @@ site:
       name: network-js
       title: Network JS
       url: '#'
+      deprecated: true
       versions:
       - &latest_version_abc
         url: '#' 

--- a/ui/preview-src/ui-model.yml
+++ b/ui/preview-src/ui-model.yml
@@ -39,9 +39,9 @@ site:
         version: '1.x'
         displayVersion: '1.x'
       latestVersion: *latest_version_contracts
-    sdk:
-      name: sdk
-      title: SDK
+    cli:
+      name: cli
+      title: CLI
       url: '#'
       versions:
       - &latest_version_sdk
@@ -52,6 +52,19 @@ site:
         version: '2.4'
         displayVersion: '2.3'
       latestVersion: *latest_version_sdk
+    upgrades:
+      name: upgrades
+      title: Upgrades
+      url: '#'
+      versions:
+      - &latest_version_upgrades
+        url: '#' 
+        version: '2.5'
+        displayVersion: '2.5'
+      - url: '#' 
+        version: '2.4'
+        displayVersion: '2.3'
+      latestVersion: *latest_version_upgrades
     starter-kits:
       name: starter-kits
       title: Starter Kits
@@ -89,7 +102,6 @@ site:
       name: network-js
       title: Network JS
       url: '#'
-      deprecated: true
       versions:
       - &latest_version_abc
         url: '#' 

--- a/ui/src/helpers/any.js
+++ b/ui/src/helpers/any.js
@@ -1,0 +1,10 @@
+'use strict'
+
+module.exports = (collection, predicate) => {
+  for (const key in collection) {
+    if (collection[key][predicate]) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/ui/src/helpers/in.js
+++ b/ui/src/helpers/in.js
@@ -1,3 +1,3 @@
 'use strict'
 
-module.exports = (needle, list) => list.includes(needle);
+module.exports = (needle, list) => list.split(/, */).includes(needle);

--- a/ui/src/helpers/in.js
+++ b/ui/src/helpers/in.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (needle, list) => list.includes(needle);

--- a/ui/src/helpers/omit.js
+++ b/ui/src/helpers/omit.js
@@ -1,0 +1,14 @@
+module.exports = function (obj, selection, opts) {
+  if (opts === undefined) {
+    throw new Error('Must pass object and selection to #omit');
+  }
+
+  const keys = selection ? selection.split(/, */) : [];
+  const result = {};
+  for (const key in obj) {
+    if (!keys.includes(key)) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+}

--- a/ui/src/helpers/pick.js
+++ b/ui/src/helpers/pick.js
@@ -4,5 +4,11 @@ module.exports = function (obj, selection, opts) {
   }
 
   const keys = selection ? selection.split(/, */) : [];
-  return keys.reduce((res, key) => Object.assign(res, { [key]: obj[key] }), {});
+  const result = {};
+  for (const key of keys) {
+    if (obj[key]) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
 }

--- a/ui/src/helpers/pick.js
+++ b/ui/src/helpers/pick.js
@@ -1,0 +1,8 @@
+module.exports = function (obj, selection, opts) {
+  if (opts === undefined) {
+    throw new Error('Must pass object and selection to #pick');
+  }
+
+  const keys = selection ? selection.split(/, */) : [];
+  return keys.map(key => opts.fn(obj[key])).join('');
+}

--- a/ui/src/helpers/pick.js
+++ b/ui/src/helpers/pick.js
@@ -4,5 +4,5 @@ module.exports = function (obj, selection, opts) {
   }
 
   const keys = selection ? selection.split(/, */) : [];
-  return keys.map(key => opts.fn(obj[key])).join('');
+  return keys.reduce((res, key) => Object.assign(res, { [key]: obj[key] }), {});
 }

--- a/ui/src/helpers/split.js
+++ b/ui/src/helpers/split.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (list) => list.split(/, */);

--- a/ui/src/helpers/split.js
+++ b/ui/src/helpers/split.js
@@ -1,3 +1,0 @@
-'use strict'
-
-module.exports = (list) => list.split(/, */);

--- a/ui/src/images/test-helpers_white.svg
+++ b/ui/src/images/test-helpers_white.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 62 (91390) - https://sketch.com -->
+    <title>ic/ testhelpers</title>
+    <desc>Created with Sketch.</desc>
+    <g id="ic/-testhelpers" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path d="M18,13.1825397 L18,17.5 L6.35294118,17.5 L6.35294118,13.1825397 L18,13.1825397 Z M4.23529412,13.1825397 L4.23529412,17.5 L0,17.5 L0,13.1825397 L4.23529412,13.1825397 Z M11.6470588,6.70634921 L11.6470588,11.0238095 L0,11.0238095 L0,6.70634921 L11.6470588,6.70634921 Z M18,6.70634921 L18,11.0238095 L13.7647059,11.0238095 L13.7647059,6.70634921 L18,6.70634921 Z M18,0.5 L18,4.81746032 L3.70588235,4.81746032 L6.35294118,0.5 L18,0.5 Z" id="Combined-Shape" fill="white"></path>
+    </g>
+</svg>

--- a/ui/src/partials/article.hbs
+++ b/ui/src/partials/article.hbs
@@ -1,5 +1,10 @@
 <div class="article-wrapper">
 	<article class="article doc">
+		{{#with @root.page.component.deprecated}}
+			<div class="article-banner">
+			<b>{{@root.page.component.title}}</b> is in maintenance mode. We are no longer actively developing new features for this project, and will only be releasing fixes for high severity issues{{#if maintenance-until}} until {{{maintenance-until}}}{{/if}}. {{#if announcement-url}}Read <a href="{{{announcement-url}}}" target="_blank_">here</a> for more info.{{/if}}
+			</div>
+		{{/with}}
 		<h1>{{{page.title}}}</h1>
 		{{{page.contents}}}
                 <div class="article-navigation">

--- a/ui/src/partials/article.hbs
+++ b/ui/src/partials/article.hbs
@@ -1,10 +1,10 @@
 <div class="article-wrapper">
 	<article class="article doc">
-		{{#with @root.page.component.deprecated}}
+		{{#if (in @root.page.component.name (split "network-js, gsn-provider, gsn-helpers, starter-kits"))}}
 			<div class="article-banner">
-			<b>{{@root.page.component.title}}</b> is in maintenance mode. We are no longer actively developing new features for this project, and will only be releasing fixes for high severity issues{{#if maintenance-until}} until {{{maintenance-until}}}{{/if}}. {{#if announcement-url}}Read <a href="{{{announcement-url}}}" target="_blank_">here</a> for more info.{{/if}}
+			<b>{{@root.page.component.title}}</b> is in maintenance mode. We are no longer actively developing new features for this project, and will only be releasing fixes for high severity issues until July 2020. Read <a href="https://example.org" target="_blank">here</a> for more info.
 			</div>
-		{{/with}}
+		{{/if}}
 		<h1>{{{page.title}}}</h1>
 		{{{page.contents}}}
                 <div class="article-navigation">

--- a/ui/src/partials/article.hbs
+++ b/ui/src/partials/article.hbs
@@ -2,7 +2,7 @@
 	<article class="article doc">
 		{{#if (in @root.page.component.name "network-js, gsn-provider, gsn-helpers, starter-kits")}}
 			<div class="article-banner">
-			<b>{{@root.page.component.title}}</b> is in maintenance mode. We are no longer actively developing new features for this project, and will only be releasing fixes for high severity issues until July 2020. Read <a href="https://example.org" target="_blank">here</a> for more info.
+			<b>{{@root.page.component.title}}</b> is in maintenance mode. We are no longer actively developing new features for this project, and will only be releasing fixes for high severity issues until July 2020. Read <a href="https://forum.openzeppelin.com/t/doubling-down-in-security/2712" target="_blank">here</a> for more info.
 			</div>
 		{{/if}}
 		<h1>{{{page.title}}}</h1>

--- a/ui/src/partials/article.hbs
+++ b/ui/src/partials/article.hbs
@@ -1,6 +1,6 @@
 <div class="article-wrapper">
 	<article class="article doc">
-		{{#if (in @root.page.component.name (split "network-js, gsn-provider, gsn-helpers, starter-kits"))}}
+		{{#if (in @root.page.component.name "network-js, gsn-provider, gsn-helpers, starter-kits")}}
 			<div class="article-banner">
 			<b>{{@root.page.component.title}}</b> is in maintenance mode. We are no longer actively developing new features for this project, and will only be releasing fixes for high severity issues until July 2020. Read <a href="https://example.org" target="_blank">here</a> for more info.
 			</div>

--- a/ui/src/partials/navigation-component.hbs
+++ b/ui/src/partials/navigation-component.hbs
@@ -1,0 +1,6 @@
+<div class="nav-component">
+  <a class="flex align-center" href="{{{./url}}}" tabindex="0">
+    <img class="nav-icon" src="{{@root.uiRootPath}}/images/icons/{{{this.name}}}.svg">
+    <span class="nav-component-heading">{{{./title}}}</span>
+  </a>
+</div>

--- a/ui/src/partials/navigation.hbs
+++ b/ui/src/partials/navigation.hbs
@@ -7,13 +7,25 @@
 
   {{#if (eq @root.page.component.name "openzeppelin")}}
   <div class="nav-components">
-    {{#sorted site.components "openzeppelin, learn, contracts, cli, starter-kits, test-environment, test-helpers, upgrades, network.js, gsn-provider, gsn-helpers, contract-loader"}}
+    <h3 class="nav-title">Start here</h3>
+    {{#select site.components "openzeppelin, learn"}}
     <div class="nav-component">
       <a class="flex align-center" href="{{{./url}}}" tabindex="0">
         <img class="nav-icon" src="{{@root.uiRootPath}}/images/icons/{{{this.name}}}.svg">
         <span class="nav-component-heading">{{{./title}}}</span>
       </a>
     </div>
+    {{/select}}
+    <h3 class="nav-title">Tools &amp; Libraries</h3>
+    {{#sorted site.components "contracts, cli, starter-kits, test-environment, test-helpers, upgrades, network.js, gsn-provider, gsn-helpers, contract-loader"}}
+    {{#unless deprecated}}
+    <div class="nav-component">
+      <a class="flex align-center" href="{{{./url}}}" tabindex="0">
+        <img class="nav-icon" src="{{@root.uiRootPath}}/images/icons/{{{this.name}}}.svg">
+        <span class="nav-component-heading">{{{./title}}}</span>
+      </a>
+    </div>
+    {{/unless}}
     {{/sorted}}
   </div>
 

--- a/ui/src/partials/navigation.hbs
+++ b/ui/src/partials/navigation.hbs
@@ -8,12 +8,12 @@
   {{#if (eq @root.page.component.name "openzeppelin")}}
   <div class="nav-components">
     <h3 class="nav-title">Start here</h3>
-    {{#pick site.components "openzeppelin, learn"}}
+    {{#each (pick site.components "openzeppelin, learn")}}
       {{> navigation-component }}
-    {{/pick}}
+    {{/each}}
     
     <h3 class="nav-title">Our Tools &amp; Libraries</h3>
-    {{#sorted site.components "contracts, contract-loader, cli, upgrades, starter-kits, test-helpers, test-environment, network.js, gsn-provider, gsn-helpers, docgen, hot-loader"}}
+    {{#sorted (omit site.components "openzeppelin, learn") "contracts, contract-loader, cli, upgrades, starter-kits, test-helpers, test-environment, network.js, gsn-provider, gsn-helpers, docgen, hot-loader"}}
       {{#unless deprecated}}
         {{> navigation-component }}
       {{/unless}}
@@ -21,7 +21,7 @@
     {{#if (any site.components "deprecated")}}
       <h3 class="nav-title">Maintenance updates only</h3>
     {{/if}}
-    {{#sorted site.components "contracts, contract-loader, cli, upgrades, starter-kits, test-helpers, test-environment, network.js, gsn-provider, gsn-helpers, docgen, hot-loader"}}
+    {{#sorted (omit site.components "openzeppelin, learn") "contracts, contract-loader, cli, upgrades, starter-kits, test-helpers, test-environment, network.js, gsn-provider, gsn-helpers, docgen, hot-loader"}}
       {{#if deprecated}}
         {{> navigation-component }}
       {{/if}}

--- a/ui/src/partials/navigation.hbs
+++ b/ui/src/partials/navigation.hbs
@@ -13,19 +13,14 @@
     {{/each}}
     
     <h3 class="nav-title">Our Tools &amp; Libraries</h3>
-    {{#sorted (omit site.components "openzeppelin, learn") "contracts, contract-loader, cli, upgrades, starter-kits, test-helpers, test-environment, network.js, gsn-provider, gsn-helpers, docgen, hot-loader"}}
-      {{#unless deprecated}}
-        {{> navigation-component }}
-      {{/unless}}
-    {{/sorted}}
-    {{#if (any site.components "deprecated")}}
-      <h3 class="nav-title">Maintenance updates only</h3>
-    {{/if}}
-    {{#sorted (omit site.components "openzeppelin, learn") "contracts, contract-loader, cli, upgrades, starter-kits, test-helpers, test-environment, network.js, gsn-provider, gsn-helpers, docgen, hot-loader"}}
-      {{#if deprecated}}
-        {{> navigation-component }}
-      {{/if}}
-    {{/sorted}}
+    {{#each (pick site.components "contracts, contract-loader, cli, upgrades, test-helpers, test-environment, docgen, hot-loader")}}
+      {{> navigation-component }}
+    {{/each}}
+
+    <h3 class="nav-title">Maintenance updates only</h3>
+    {{#each (pick site.components "starter-kits, network-js, gsn-provider, gsn-helpers")}}
+      {{> navigation-component }}
+    {{/each}}
   </div>
 
   {{else}}

--- a/ui/src/partials/navigation.hbs
+++ b/ui/src/partials/navigation.hbs
@@ -13,9 +13,9 @@
     {{/each}}
     
     <h3 class="nav-title">Our Tools &amp; Libraries</h3>
-    {{#each (pick site.components "contracts, contract-loader, cli, upgrades, test-helpers, test-environment, docgen, hot-loader")}}
+    {{#sorted (omit site.components "openzeppelin, learn, starter-kits, network-js, gsn-provider, gsn-helpers") "contracts, contract-loader, cli, upgrades, test-helpers, test-environment, docgen, hot-loader"}}
       {{> navigation-component }}
-    {{/each}}
+    {{/sorted}}
 
     <h3 class="nav-title">Maintenance updates only</h3>
     {{#each (pick site.components "starter-kits, network-js, gsn-provider, gsn-helpers")}}

--- a/ui/src/partials/navigation.hbs
+++ b/ui/src/partials/navigation.hbs
@@ -8,24 +8,23 @@
   {{#if (eq @root.page.component.name "openzeppelin")}}
   <div class="nav-components">
     <h3 class="nav-title">Start here</h3>
-    {{#select site.components "openzeppelin, learn"}}
-    <div class="nav-component">
-      <a class="flex align-center" href="{{{./url}}}" tabindex="0">
-        <img class="nav-icon" src="{{@root.uiRootPath}}/images/icons/{{{this.name}}}.svg">
-        <span class="nav-component-heading">{{{./title}}}</span>
-      </a>
-    </div>
-    {{/select}}
-    <h3 class="nav-title">Tools &amp; Libraries</h3>
-    {{#sorted site.components "contracts, cli, starter-kits, test-environment, test-helpers, upgrades, network.js, gsn-provider, gsn-helpers, contract-loader"}}
-    {{#unless deprecated}}
-    <div class="nav-component">
-      <a class="flex align-center" href="{{{./url}}}" tabindex="0">
-        <img class="nav-icon" src="{{@root.uiRootPath}}/images/icons/{{{this.name}}}.svg">
-        <span class="nav-component-heading">{{{./title}}}</span>
-      </a>
-    </div>
-    {{/unless}}
+    {{#pick site.components "openzeppelin, learn"}}
+      {{> navigation-component }}
+    {{/pick}}
+    
+    <h3 class="nav-title">Our Tools &amp; Libraries</h3>
+    {{#sorted site.components "contracts, contract-loader, cli, upgrades, starter-kits, test-helpers, test-environment, network.js, gsn-provider, gsn-helpers, docgen, hot-loader"}}
+      {{#unless deprecated}}
+        {{> navigation-component }}
+      {{/unless}}
+    {{/sorted}}
+    {{#if (any site.components "deprecated")}}
+      <h3 class="nav-title">Maintenance updates only</h3>
+    {{/if}}
+    {{#sorted site.components "contracts, contract-loader, cli, upgrades, starter-kits, test-helpers, test-environment, network.js, gsn-provider, gsn-helpers, docgen, hot-loader"}}
+      {{#if deprecated}}
+        {{> navigation-component }}
+      {{/if}}
     {{/sorted}}
   </div>
 

--- a/ui/src/stylesheets/article.scss
+++ b/ui/src/stylesheets/article.scss
@@ -246,7 +246,7 @@
 .article-banner {
   background-color: var(--aluminum-2);
   border: solid 1px var(--aluminum-4);
-  border-radius: 5px;
+  border-radius: var(--border-radius);
   padding: 10px;
   margin: 0 -10px;
 }

--- a/ui/src/stylesheets/article.scss
+++ b/ui/src/stylesheets/article.scss
@@ -243,6 +243,14 @@
   }
 }
 
+.article-banner {
+  background-color: var(--aluminum-2);
+  border: solid 1px var(--aluminum-4);
+  border-radius: 5px;
+  padding: 10px;
+  margin: 0 -10px;
+}
+
 @media (max-width: $mobile-breakpoint) {
   .article {
     margin-left: var(--lg);

--- a/ui/src/stylesheets/components/cards.scss
+++ b/ui/src/stylesheets/components/cards.scss
@@ -95,7 +95,7 @@
   background-image: linear-gradient(-134deg, #3677ff 0%, #1ecff7 100%);
 }
 
-.card-test-helpers a { 
+.card-test-helpers a {
   --card-icon: url(../images/test-helpers_white.svg);
   background-image: linear-gradient(-135deg, #00e1d4 0%, #00c7f2 100%);
 }

--- a/ui/src/stylesheets/components/cards.scss
+++ b/ui/src/stylesheets/components/cards.scss
@@ -95,8 +95,8 @@
   background-image: linear-gradient(-134deg, #3677ff 0%, #1ecff7 100%);
 }
 
-.card-starter-kits a {
-  --card-icon: url(../images/kit_white.svg);
+.card-test-helpers a { 
+  --card-icon: url(../images/test-helpers_white.svg);
   background-image: linear-gradient(-135deg, #00e1d4 0%, #00c7f2 100%);
 }
 
@@ -115,7 +115,6 @@
 
 .card-upgrades-js { --card-icon: url(../images/icons/sdk.svg); }
 .card-test-environment { --card-icon: url(../images/icons/test-environment.svg); }
-.card-test-helpers { --card-icon: url(../images/icons/test-helpers.svg); }
 .card-network-js { --card-icon: url(../images/icons/network-js.svg); }
 .card-gsn-helpers { --card-icon: url(../images/icons/gsn-helpers.svg); }
 .card-gsn-provider { --card-icon: url(../images/icons/gsn-provider.svg); }

--- a/ui/src/stylesheets/specific/navigation.scss
+++ b/ui/src/stylesheets/specific/navigation.scss
@@ -25,6 +25,23 @@
 
 .nav-components {
   height: calc(100% - 25px);
+
+  hr {
+    background-color: var(--aluminum-4);
+    border-style: none;
+    height: 1px;
+  }
+}
+
+.nav-title {
+  margin: 1em 0 .2em 0;
+  padding: 0;
+  font-size: .8em;
+  font-family: var(--heading);
+  color: var(--aluminum-5);
+  letter-spacing: .05em;
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
 }
 
 .btn-back {

--- a/ui/src/stylesheets/specific/navigation.scss
+++ b/ui/src/stylesheets/specific/navigation.scss
@@ -25,12 +25,6 @@
 
 .nav-components {
   height: calc(100% - 25px);
-
-  hr {
-    background-color: var(--aluminum-4);
-    border-style: none;
-    height: 1px;
-  }
 }
 
 .nav-title {


### PR DESCRIPTION
This PR moves network.js, gsn, and starter kits to maintenance mode. Read [here](https://forum.openzeppelin.com/t/doubling-down-in-security/2712) for more info.