### PR TITLE
Reorder sidebar and home cards

### DIFF
--- a/components/home/modules/ROOT/pages/index.adoc
+++ b/components/home/modules/ROOT/pages/index.adoc
@@ -35,6 +35,11 @@ xref:cli::index.adoc[[.card-title]#CLI# [.card-body]#A command-line tool to help
 xref:test-helpers::index.adoc[[.card-title]#Test Helpers# [.card-body]#A JavaScript library of common assertions for smart contracts+++,+++ which can be used with test-environment+++,+++ truffle+++,+++ or vanilla web3-js setups.#]
 --
 
+[.card.card-secondary.card-solidity-docgen]
+--
+https://github.com/OpenZeppelin/solidity-docgen[[.card-title]#Solidity Docgen# [.card-body]#A tool for automatically generating documentation based on the natspec comments of your Solidity contracts.#]
+--
+
 [.card.card-secondary.card-upgrades-js]
 --
 xref:upgrades::index.adoc[[.card-title]#Upgrades# [.card-body]#A JavaScript library for managing upgradeable contracts+++,+++ which powers the OpenZeppelin CLI.#]
@@ -47,17 +52,12 @@ xref:test-environment::index.adoc[[.card-title]#Test Environment# [.card-body]#A
 
 [.card.card-secondary.card-contract-loader]
 --
-xref:contract-loader::index.adoc[[.card-title]#Contract Loader# [.card-body]#A minimal JavaScript library for loading contract artifacts by name or ABI.#]
+https://github.com/OpenZeppelin/solidity-loader[[.card-title]#Hot Loader# [.card-body]#A webpack plugin for automatically compiling and upgrading your contracts locally while you develop.#]
 --
 
 [.card.card-secondary.card-contract-loader]
 --
-https://github.com/OpenZeppelin/solidity-loader[[.card-title]#Hot Loader# [.card-body]#A webpack plugin for automatically compiling and upgrading your contracts locally while you develop.#]
---
-
-[.card.card-secondary.card-solidity-docgen]
---
-https://github.com/OpenZeppelin/solidity-docgen[[.card-title]#Solidity Docgen# [.card-body]#A tool for automatically generating documentation based on the natspec comments of your Solidity contracts.#]
+xref:contract-loader::index.adoc[[.card-title]#Contract Loader# [.card-body]#A minimal JavaScript library for loading contract artifacts by name or ABI.#]
 --
 
 == More from OpenZeppelin

--- a/components/home/modules/ROOT/pages/index.adoc
+++ b/components/home/modules/ROOT/pages/index.adoc
@@ -35,11 +35,6 @@ xref:cli::index.adoc[[.card-title]#CLI# [.card-body]#A command-line tool to help
 xref:test-helpers::index.adoc[[.card-title]#Test Helpers# [.card-body]#A JavaScript library of common assertions for smart contracts+++,+++ which can be used with test-environment+++,+++ truffle+++,+++ or vanilla web3-js setups.#]
 --
 
-[.card.card-secondary.card-contract-loader]
---
-xref:contract-loader::index.adoc[[.card-title]#Contract Loader# [.card-body]#A minimal JavaScript library for loading contract artifacts by name or ABI.#]
---
-
 [.card.card-secondary.card-upgrades-js]
 --
 xref:upgrades::index.adoc[[.card-title]#Upgrades# [.card-body]#A JavaScript library for managing upgradeable contracts+++,+++ which powers the OpenZeppelin CLI.#]
@@ -48,6 +43,11 @@ xref:upgrades::index.adoc[[.card-title]#Upgrades# [.card-body]#A JavaScript libr
 [.card.card-secondary.card-test-environment]
 --
 xref:test-environment::index.adoc[[.card-title]#Test Environment# [.card-body]#A JavaScript library for creating a testing environment for contracts+++,+++ which plays nice with Mocha+++,+++ Ava+++,+++ and Jest.#]
+--
+
+[.card.card-secondary.card-contract-loader]
+--
+xref:contract-loader::index.adoc[[.card-title]#Contract Loader# [.card-body]#A minimal JavaScript library for loading contract artifacts by name or ABI.#]
 --
 
 [.card.card-secondary.card-contract-loader]

--- a/ui/src/partials/navigation.hbs
+++ b/ui/src/partials/navigation.hbs
@@ -13,7 +13,7 @@
     {{/each}}
     
     <h3 class="nav-title">Our Tools &amp; Libraries</h3>
-    {{#sorted (omit site.components "openzeppelin, learn, starter-kits, network-js, gsn-provider, gsn-helpers") "contracts, contract-loader, cli, upgrades, test-helpers, test-environment, docgen, hot-loader"}}
+    {{#sorted (omit site.components "openzeppelin, learn, starter-kits, network-js, gsn-provider, gsn-helpers") "contracts, test-helpers, test-environment, cli, upgrades, contract-loader"}}
       {{> navigation-component }}
     {{/sorted}}
 


### PR DESCRIPTION
I reordered the sidebar placing test-helpers and test-env higher, and moving contract-loader to the bottom since it's more of an internal thing.

I also removed two project names that don't have entries in the sidebar.