### PR TITLE
Update Learn guides to Solidity 0.6 and use `oz deploy`

### DIFF
--- a/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
+++ b/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
@@ -54,7 +54,7 @@ To send transactions in a testnet, you will need a new Ethereum account. There a
 [source,console]
 ----
 $ npx mnemonics
-mistake pelican mention moment ...
+pioneer tent curve wild ...
 ----
 
 WARNING: Make sure to keep your mnemonic secure. Even if it is just for testing purposes, there are still malicious users out there who will wreak havoc on your testnet deployment for fun!
@@ -103,7 +103,7 @@ Note in the first line that we are loading the project id and mnemonic from a `s
 [source,json]
 ----
 {
-  "mnemonic": "mistake pelican mention moment ...",
+  "mnemonic": "pioneer tent curve wild ...",
   "projectId": "305c13705054a8d918ad77549e402c72"
 }
 ----
@@ -115,14 +115,14 @@ We can now test out that this configuration is working by listing the accounts w
 [source,console]
 ----
 $ npx oz accounts
-? Pick a network: rinkeby
+? Pick a network rinkeby
 Accounts for rinkeby:
-Default: 0xf0A9eD2663311CE436347Bb6F240181FF103CA16
+Default: 0xc38C62Af27e329aD58e889E7AE3070B1db571eB0
 All:
-- 0: 0xf0A9eD2663311CE436347Bb6F240181FF103CA16
-- 1: 0x3B9861c7D3e7BBd41602d9FfaCEF10BC04867Bc0
-- 2: 0x8C7623AC7Fe2E635Fa256791C25dA2c8851c5F08
-- 3: 0xd86f3FeeFd93bd19acaFd212D8630DEDeb56C6bd
+- 0: 0xc38C62Af27e329aD58e889E7AE3070B1db571eB0
+- 1: 0xE8595815B50088fd4371f2E52fb2F5eeAfd654ac
+- 2: 0x1Ad3B46f8d23d84380c618F4aD33Bf49E2Df7f25
+- 3: 0xebfb88b31bdDead46a909276D3A69e2b712A2Aa3
 ...
 ----
 
@@ -131,9 +131,10 @@ We can also test the connection to the Infura node, by querying our account bala
 [source,console]
 ----
 $ npx oz balance
-? Enter an address to query its balance: 0xf0A9eD2663311CE436347Bb6F240181FF103CA16
-? Pick a network: rinkeby
+? Enter an address to query its balance 0xc38C62Af27e329aD58e889E7AE3070B1db571eB0
+? Pick a network rinkeby
 Balance: 0 ETH
+0
 ----
 
 Empty! This points to our next task: getting testnet funds so that we can send transactions.
@@ -152,32 +153,31 @@ With a project configured to work on a public testnet, we can now finally xref::
 
 [source,console]
 ----
-$ npx oz create
-✓ Compiled contracts with solc 0.5.12 (commit.7709ece9)
-? Pick a contract to instantiate: Box
-? Pick a network: rinkeby
-✓ Contract Box deployed
-? Call a function to initialize the instance after creating it? No
-✓ Setting everything up to create contract instances
-✓ Instance created at 0x59f3855C986920f3087FB801db3bD3B0d2DfE02C
+$ npx oz deploy
+✓ Compiled contracts with solc 0.6.7 (commit.b8d736ae)
+? Choose the kind of deployment regular
+? Pick a network rinkeby
+? Pick a contract to deploy Box
+✓ Deployed instance of Box
+0xA1a05372ECD1353105543ee46C8AA447547C6680
 ----
 
 That's it! Your `Box` contract instance will be forever stored in the testnet, and publicly accessible to anyone. The OpenZeppelin CLI will keep track of this and all your deployed contracts in `.openzeppelin/rinkeby.json`, so you can easily refer to them later, such as when upgrading or interacting with them.
 
 You can see your contract on a block explorer such as https://etherscan.io/[Etherscan]. Remember to access the explorer on the testnet where you deployed your contract, such as https://rinkeby.etherscan.io[rinkeby.etherscan.io] for Rinkeby.
 
-TIP: You can check out the contract we deployed in the example above, along with all transactions sent to it, https://rinkeby.etherscan.io/address/0x59f3855C986920f3087FB801db3bD3B0d2DfE02C[here].
+TIP: You can check out the contract we deployed in the example above, along with all transactions sent to it, https://rinkeby.etherscan.io/address/0xA1a05372ECD1353105543ee46C8AA447547C6680[here].
 
 You can also interact with your instance as you regularly would, either using the `call` and `send-tx` xref::deploying-and-interacting.adoc#interacting-from-the-command-line[CLI commands], or xref::deploying-and-interacting.adoc#interacting-programatically[programmatically using `web3`]. You can also xref:upgrading-smart-contracts.adoc[upgrade your contracts] via `oz upgrade` as you add new features to your staging project!
 
 [source,console]
 ----
 $ npx oz send-tx
-? Pick a network: rinkeby
-? Pick an instance: Box at 0x59f3855C986920f3087FB801db3bD3B0d2DfE02C
+? Pick a network rinkeby
+? Pick an instance Box at 0xA1a05372ECD1353105543ee46C8AA447547C6680
 ? Select which function store(newValue: uint256)
-? newValue (uint256): 42
-✓ Transaction successful. Transaction hash: 0x9a664c9566f265a0b11c8741cf27c87b993cf56c76660d19fcfddcdd27b31116
+? newValue: uint256: 42
+✓ Transaction successful. Transaction hash: 0xd6ef798b1c85f5dca1cf4b27f8544d6333dd1ab1f83e61a19f2cb3df203e638c
 Events emitted:
  - ValueChanged(42)
 ----

--- a/components/learn/modules/ROOT/pages/deploying-and-interacting.adoc
+++ b/components/learn/modules/ROOT/pages/deploying-and-interacting.adoc
@@ -102,7 +102,9 @@ With the <<getting-started-with-the-cli, CLI setup complete>>, we're now ready t
 [[box-contract]]
 ```solidity
 // contracts/Box.sol
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+
 
 contract Box {
     uint256 private value;
@@ -123,25 +125,23 @@ contract Box {
 }
 ```
 
-The OpenZeppelin CLI will guide you through the deployment process, asking for information as needed. Using the `create` command, deploy the `Box` contract to the `development` network (<<local-blockchain, Ganache>>), replying "no" when prompted to initialize:
+The OpenZeppelin CLI will guide you through the deployment process, asking for information as needed. Using the `deploy` command, deploy the `Box` contract to the `development` network (<<local-blockchain, Ganache>>), choosing regular when prompted with the kind of deployment:
 
 ```console
-$ npx oz create
-✓ Compiled contracts with solc 0.5.9
-? Pick a contract to instantiate Box
+$ npx oz deploy
+✓ Compiled contracts with solc 0.6.7 (commit.b8d736ae)
+? Choose the kind of deployment regular
 ? Pick a network development
-✓ Contract Box deployed
-All contracts have been deployed
-? Call a function to initialize the instance after creating it? No
-✓ Setting everything up to create contract instances
-✓ Instance created at 0xCfEB869F69431e42cdB54A4F4f105C19C080A601
+? Pick a contract to deploy Box
+✓ Deployed instance of Box
+0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab
 ```
 
 All done! On a real network this process would've taken a couple seconds, but it is instant on local blockchains.
 
 TIP: If you got a connection error, make sure you are <<local-blockchain, running Ganache>> in another terminal.
 
-The CLI will keep track of your deployed contracts, but it also displays their addresses after deployment (in our example, `0xCfEB869F69431e42cdB54A4F4f105C19C080A601`). These values will be useful when interacting with them programatically.
+The CLI will keep track of your deployed contracts, but it also displays their addresses after deployment (in our example, `0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab`). These values will be useful when interacting with them programatically.
 
 NOTE: Remember that local blockchains **do not** persist their state throughout multiple runs! If you close your Ganache process, you'll have to re-deploy your contracts.
 
@@ -159,10 +159,10 @@ This can be achieved with the CLI's `send-tx` command. Pick your `Box` contract 
 ```console
 $ npx oz send-tx
 ? Pick a network development
-? Pick an instance Box at 0xCfEB869F69431e42cdB54A4F4f105C19C080A601
+? Pick an instance Box at 0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab
 ? Select which function store(newValue: uint256)
-? newValue (uint256): 5
-✓ Transaction successful. Transaction hash: 0xe2f6d0f14719c1ec4eadcb9addef5661326e0adda5f2072ec6e1cc87d113c393
+? newValue: uint256: 5
+✓ Transaction successful. Transaction hash: 0xd40664c0a80215e964975ab3cea7f27a453c802f01c15cd754aca2c7bd6bd6c1
 Events emitted:
  - ValueChanged(5)
 ```
@@ -178,9 +178,10 @@ You may have noticed `send-tx` didn't include `retrieve` in the list of function
 ```console
 $ npx oz call
 ? Pick a network development
-? Pick an instance Box at 0xCfEB869F69431e42cdB54A4F4f105C19C080A601
+? Pick an instance Box at 0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab
 ? Select which function retrieve()
 ✓ Method 'retrieve()' returned: 5
+5
 ```
 
 Because `call` doesn't send a transaction, there is no transaction hash to report. This also means that using `call` doesn't cost any Ether, and can be used for free on any network.
@@ -250,7 +251,7 @@ These accounts should match the ones you got when you ran `oz accounts` earlier.
 [[getting-a-contract-instance]]
 === Getting a Contract Instance
 
-In order to interact with the <<box-contract,`Box`>> contract we <<deploying-a-smart-contract, deployed using the CLI>>, we'll create a new https://web3js.readthedocs.io/en/1.2.4/web3-eth-contract.html[web3 contract instance] using the xref:contract-loader::index.adoc[*OpenZeppelin Contract Loader*].
+In order to interact with the <<box-contract,`Box`>> contract we <<deploying-a-smart-contract, deployed using the CLI>>, we'll create a new https://web3js.readthedocs.io/en/v1.2.7/web3-eth-contract.html[web3 contract instance] using the xref:contract-loader::index.adoc[*OpenZeppelin Contract Loader*].
 
 A web3 contract instance is a JavaScript object that represents our contract on the blockchain, which we can use to interact with our contract. To create one we need to provide the Contract Loader with the contract name and the address where it was deployed, which the CLI returned when we ran `oz create`.
 
@@ -261,7 +262,7 @@ const web3 = new Web3('http://localhost:8545');
 const loader = setupLoader({ provider: web3 }).web3;
 
 // Set up a web3 contract, representing our deployed Box instance, using the contract loader
-const address = '0xCfEB869F69431e42cdB54A4F4f105C19C080A601';
+const address = '0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab';
 const box = loader.fromArtifact('Box', address);
 ----
 
@@ -299,9 +300,9 @@ If this happens, simply <<local-blockchain, start ganache>> and <<deploying-a-sm
 [[sending-a-transaction]]
 === Sending a Transaction
 
-We'll now https://web3js.readthedocs.io/en/1.0/web3-eth-contract.html#methods-mymethod-send[send a transaction] to `store` a new value in our Box. Remember that sending a transaction is not as straightforward as making a call: we need to specify who the sender will be, the gas limit, and the gas price we are going to use. To keep this example simple, we'll use a hardcoded value for both gas and gas price, and send the transaction from the first available account on the node.
+We'll now https://web3js.readthedocs.io/en/v1.2.7/web3-eth-contract.html#methods-mymethod-send[send a transaction] to `store` a new value in our Box. Remember that sending a transaction is not as straightforward as making a call: we need to specify who the sender will be, the gas limit, and the gas price we are going to use. To keep this example simple, we'll use a hardcoded value for both gas and gas price, and send the transaction from the first available account on the node.
 
-NOTE: In a real-world application, you may want to https://web3js.readthedocs.io/en/1.0/web3-eth-contract.html#methods-mymethod-estimategas[estimate the gas] of your transactions, and check a https://ethgasstation.info/[gas price oracle] to know the optimal values to use on every transaction.
+NOTE: In a real-world application, you may want to https://web3js.readthedocs.io/en/v1.2.7/web3-eth-contract.html#methods-mymethod-estimategas[estimate the gas] of your transactions, and check a https://ethgasstation.info/[gas price oracle] to know the optimal values to use on every transaction.
 
 Let's store a value of `20` in our `Box`, and then use the code we had written before to display the updated value:
 

--- a/components/learn/modules/ROOT/pages/developing-smart-contracts.adoc
+++ b/components/learn/modules/ROOT/pages/developing-smart-contracts.adoc
@@ -29,7 +29,9 @@ We will save this file as `contracts/Box.sol`. Each `.sol` file should have the 
 
 ```solidity
 // contracts/Box.sol
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+
 
 contract Box {
     uint256 private value;
@@ -78,7 +80,7 @@ You will notice a `build/contracts` directory was created: it holds the compiled
 You can also configure your compilation, which includes choosing a compiler version and enabling optimizations, by passing arguments to the `compile` command:
 
 ```console
-$ npx oz compile --solc-version=0.5.12 --optimizer on
+$ npx oz compile --solc-version=0.6.7 --optimizer on
 ```
 
 For detailed information on these options, refer to xref:cli::compiling.adoc[Compiling With the CLI].
@@ -95,12 +97,14 @@ Because the compiler will pick up all files in the `contracts` directory and sub
 [[auth-contract]]
 ```solidity
 // contracts/access-control/Auth.sol
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+
 
 contract Auth {
     address private administrator;
 
-    constructor () public {
+    constructor() public {
         // Make the deployer of the contract the administrator
         administrator = msg.sender;
     }
@@ -115,10 +119,12 @@ To use this contract from `Box` we use an `import` statement, referring to `Auth
 
 ```solidity
 // contracts/Box.sol
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
 
 // Import Auth from the access-control subdirectory
 import "./access-control/Auth.sol";
+
 
 contract Box {
     uint256 private value;
@@ -172,15 +178,17 @@ $ npm install --save-dev @openzeppelin/contracts
 
 NOTE: You should always use the library from these published releases: copy-pasting library source code into your project is a dangerous practice that makes it very easy to introduce security vulnerabilities in your contracts.
 
-To use one of the OpenZeppelin Contracts, `import` it by prefixing its path with `@openzeppelin/contracts`. For example, in order to replace our own <<auth-contract, `Auth`>> contract, we will import `@openzeppelin/contracts/ownership/Ownable.sol` to add access control to `Box`:
+To use one of the OpenZeppelin Contracts, `import` it by prefixing its path with `@openzeppelin/contracts`. For example, in order to replace our own <<auth-contract, `Auth`>> contract, we will import `@openzeppelin/contracts/access/Ownable.sol` to add access control to `Box`:
 
 [[box-contract]]
 ```solidity
 // contracts/Box.sol
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
 
 // Import Ownable from the OpenZeppelin Contracts library
-import "@openzeppelin/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
 
 // Make Box inherit from the Ownable contract
 contract Box is Ownable {

--- a/components/learn/modules/ROOT/pages/upgrading-smart-contracts.adoc
+++ b/components/learn/modules/ROOT/pages/upgrading-smart-contracts.adoc
@@ -38,7 +38,9 @@ Let's see how it works, by upgrading the `Box` contract xref:deploying-and-inter
 
 ```solidity
 // contracts/Box.sol
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+
 
 contract Box {
     uint256 private value;
@@ -59,7 +61,34 @@ contract Box {
 }
 ```
 
-NOTE: If you had stopped and restarted ganache between the xref:deploying-and-interacting.adoc[deployment guide] and this one, you will need to first `create` a new `Box` instance, so you can now upgrade it.
+We need to first `deploy` a new `Box` instance as an upgradeable contract (we previously deployed regular non-upgradeable contracts), so we can then upgrade it.
+
+```bash
+$ npx oz deploy
+✓ Compiled contracts with solc 0.6.7 (commit.b8d736ae)
+? Choose the kind of deployment upgradeable
+? Pick a network development
+? Pick a contract to deploy Box
+✓ Contract Box deployed
+All implementations have been deployed
+? Call a function to initialize the instance after creating it? No
+✓ Setting everything up to create contract instances
+✓ Instance created at 0xCfEB869F69431e42cdB54A4F4f105C19C080A601
+To upgrade this instance run 'oz upgrade'
+0xCfEB869F69431e42cdB54A4F4f105C19C080A601
+```
+
+Then store a value.
+```bash
+$ npx oz send-tx
+? Pick a network development
+? Pick an instance Box at 0xCfEB869F69431e42cdB54A4F4f105C19C080A601
+? Select which function store(newValue: uint256)
+? newValue: uint256: 5
+✓ Transaction successful. Transaction hash: 0x9c15e805959a1fb9cbf6e7e108094b02c3d439ec1190549bff1166731e0e2274
+Events emitted:
+ - ValueChanged(5)
+```
 
 For the sake of the example, let's say we want to add a new feature: a function that increments the `value` stored in the `Box`.
 
@@ -79,12 +108,16 @@ contract Box {
 After changing the Solidity file, we can now just upgrade the instance we had deployed earlier by running the `openzeppelin upgrade` command.
 
 ```bash
-$ npx openzeppelin upgrade
-? Pick a network: development
-✓ Compiled contracts with solc 0.5.9
+$ npx oz upgrade
+? Pick a network development
+? Which instances would you like to upgrade? Choose by name
+? Pick an instance to upgrade Box
+? Call a function on the instance after upgrading it? No
+✓ Compiled contracts with solc 0.6.7 (commit.b8d736ae)
 ✓ Contract Box deployed
-? Which instances would you like to upgrade?: All instances
-Instance upgraded at 0xCfEB869F69431e42cdB54A4F4f105C19C080A601.
+All implementations have been deployed
+✓ Instance upgraded at 0xCfEB869F69431e42cdB54A4F4f105C19C080A601. Transaction receipt: 0xcd85e8481c8e15f37a2822e5ac829cec315484dc8cddde37625270358ff9370f
+✓ Instance at 0xCfEB869F69431e42cdB54A4F4f105C19C080A601 upgraded
 ```
 
 Done! Our `Box` instance has been upgraded to the latest version of the code, *while keeping its state and the same address as before*. We didn't need to deploy a new one at a new address, nor manually copy the `value` from the old `Box` to the new one.
@@ -92,19 +125,20 @@ Done! Our `Box` instance has been upgraded to the latest version of the code, *w
 Let's try it out by invoking the new `increment` function, and checking the `value` afterwards:
 
 ```bash
-$ npx openzeppelin send-tx
-? Pick a network: development
-? Pick an instance: Box at 0xCfEB869F69431e42cdB54A4F4f105C19C080A601
-? Select which function: increment()
-✓ Transaction successful: 0x9c84faf32a87a33f517b424518712f1dc5ba0bdac4eae3a67ca80a393c555ece
+$ npx oz send-tx
+? Pick a network development
+? Pick an instance Box at 0xCfEB869F69431e42cdB54A4F4f105C19C080A601
+? Select which function increment()
+✓ Transaction successful. Transaction hash: 0xb3eaceb24df52c4933d868113aabb02c12a91080e0c923373e1ddedae7b46325
 Events emitted:
-- ValueChanged(6)
+ - ValueChanged(6)
 
-$ npx openzeppelin call
-? Pick a network: development
-? Pick an instance: Box at 0xCfEB869F69431e42cdB54A4F4f105C19C080A601
-? Select which function: retrieve()
+$ npx oz call
+? Pick a network development
+? Pick an instance Box at 0xCfEB869F69431e42cdB54A4F4f105C19C080A601
+? Select which function retrieve()
 ✓ Method 'retrieve()' returned: 6
+6
 ```
 
 That's it! Notice how the `value` of the `Box` was preserved throughout the upgrade, as well as its address. And this process is the same regardless of whether you are working on a local blockchain, a testnet, or the main network. Let's see how the OpenZeppelin CLI accomplishes this.
@@ -203,13 +237,18 @@ As an example, let's write a new version of the `Box` contract with an initializ
 
 ```solidity
 // contracts/AdminBox.sol
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
 
 import "@openzeppelin/upgrades/contracts/Initializable.sol";
+
 
 contract AdminBox is Initializable {
     uint256 private value;
     address private admin;
+
+    // Emitted when the stored value changes
+    event ValueChanged(uint256 newValue);
 
     function initialize(address _admin) public initializer {
         admin = _admin;
@@ -217,7 +256,7 @@ contract AdminBox is Initializable {
 
     // Stores a new value in the contract
     function store(uint256 newValue) public {
-        require(msg.sender == admin);
+        require(msg.sender == admin, "AdminBox: not admin");
         value = newValue;
         emit ValueChanged(newValue);
     }
@@ -232,16 +271,19 @@ contract AdminBox is Initializable {
 When deploying this contract, the CLI will prompt us to execute the initializer and ask us to provide the admin address.
 
 ```bash
-$ npx oz create
-✓ Compiled contracts with solc 0.5.9
-? Pick a contract to instantiate: AdminBox
-? Pick a network: development
+$ npx oz deploy
+Nothing to compile, all contracts are up to date.
+? Choose the kind of deployment upgradeable
+? Pick a network development
+? Pick a contract to deploy AdminBox
 ✓ Contract AdminBox deployed
+All implementations have been deployed
 ? Call a function to initialize the instance after creating it? Yes
-? Select which function: initialize(_admin: address)
-? _admin (address): 0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1
-✓ Setting everything up to create contract instances
-✓ Instance created at 0x2612Af3A521c2df9EAF28422Ca335b04AdF3ac66
+? Select which function * initialize(admin: address)
+? admin: address: 0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1
+✓ Instance created at 0xC89Ce4735882C9F0f0FE26686c53074E09B0D550
+To upgrade this instance run 'oz upgrade'
+0xC89Ce4735882C9F0f0FE26686c53074E09B0D550
 ```
 
 For all practical purposes, the initializer acts as a constructor. However, keep in mind that since it's a regular function, you will need to manually call the initializers of all base contracts (if any).

--- a/components/learn/modules/ROOT/pages/writing-automated-tests.adoc
+++ b/components/learn/modules/ROOT/pages/writing-automated-tests.adoc
@@ -183,7 +183,7 @@ describe('Box', function () {
 
 No configuration is required: Test Environment will detect the Test Helpers and do the hard work for you.
 
-These will test properties of the `Box` contract xref:developing-smart-contracts.adoc#using-openzeppelin-contracts[from previous guides]: a simple contract that lets you `retrieve` a value the owner previously `store` d.
+These will test properties of the `Box` contract xref:developing-smart-contracts.adoc#using-openzeppelin-contracts[from previous guides]: a simple contract that lets you `retrieve` a value the owner previously `store`d.
 
 Run your tests again to see the Test Helpers in action:
 

--- a/components/learn/modules/ROOT/pages/writing-automated-tests.adoc
+++ b/components/learn/modules/ROOT/pages/writing-automated-tests.adoc
@@ -183,6 +183,8 @@ describe('Box', function () {
 
 No configuration is required: Test Environment will detect the Test Helpers and do the hard work for you.
 
+These will test properties of the `Box` contract xref:developing-smart-contracts.adoc#using-openzeppelin-contracts[from previous guides]: a simple contract that lets you `retrieve` a value the owner previously `store` d.
+
 Run your tests again to see the Test Helpers in action:
 
 ```console


### PR DESCRIPTION
Update Learn guides to:
* Solidity 0.6
* use `oz deploy` (`oz create` deprecated)
* deploy regular contracts
* add SPDX license (MIT) headers
* add `deploy` and `send-tx` prior to upgrade in upgrade guide
* use new mnemonic in public testnet guide (to redo examples)
* update web3 document references
* add link to `Box` contract inheriting from OpenZeppelin Contracts in advanced testing section
* update to use OpenZeppelin Contracts 3.x Ownable

