### PR TITLE
Explain explicitly setting hardhat network

### DIFF
--- a/components/learn/modules/ROOT/pages/deploying-and-interacting.adoc
+++ b/components/learn/modules/ROOT/pages/deploying-and-interacting.adoc
@@ -233,6 +233,8 @@ We will use the https://hardhat.org/guides/hardhat-console.html[Hardhat console]
 
 NOTE: We need to specify the address of our `Box` contract we displayed in our deploy script.
 
+NOTE: It's important that we explicitly set the network for Hardhat to connect our console session to. If we don't, Hardhat will default to using a new ephemeral network, which our Box contract wouldn't be deployed to.
+
 ```console
 $ npx hardhat console --network localhost
 > const Box = await ethers.getContractFactory("Box")


### PR DESCRIPTION
Not explicitly setting the Hardhat network in `npx hardhat console` caught me out because I had assumed Hardhat would by default connect to the `localhost` network. It was my mistake, but it was very difficult to debug and stopped me from progressing through this awesome guide.

Because I think the default of creating and using a new, ephemeral network is unintuitive, adding a note explaining it could help other followers of guide not make the same mistake.