### PR TITLE
Resolve code block copy issue #296

### DIFF
--- a/ui/src/js/07-copy-code.js
+++ b/ui/src/js/07-copy-code.js
@@ -14,13 +14,13 @@
     let code = e.target.parentElement.innerText;
     const codeParentElement = e.target.parentElement;
     const codeElement = codeParentElement.querySelector(codeElementSelector);
-    const codeLanguage = codeElement.dataset.lang;
-    const isShellLanguage = shellAliases.indexOf(codeLanguage) >= 0;
+    const codeLanguage = codeElement?.dataset?.lang;
+    const isShellLanguage = shellAliases.includes(codeLanguage);
 
     if (isShellLanguage) {
-      const [firstChar] = code;
-      code = firstChar === '$' ? code.substring(2) : code;
+      code = code.replace(/\$ /gm, '');
     }
+
     navigator.clipboard.writeText(code);
   }
 

--- a/ui/src/js/07-copy-code.js
+++ b/ui/src/js/07-copy-code.js
@@ -1,4 +1,7 @@
 (function () {
+  const codeElementSelector = '[data-lang]';
+  const shellAliases = ['console', 'shell', 'sh', 'bash'];
+
   function onDOMContentLoaded(callback) {
     if (document.readyState === 'loading') {
       document.addEventListener('DOMContentLoaded', callback);
@@ -8,7 +11,16 @@
   }
 
   function copyClick(e) {
-    const code = e.target.parentElement.innerText;
+    let code = e.target.parentElement.innerText;
+    const codeParentElement = e.target.parentElement;
+    const codeElement = codeParentElement.querySelector(codeElementSelector);
+    const codeLanguage = codeElement.dataset.lang;
+    const isShellLanguage = shellAliases.indexOf(codeLanguage) >= 0;
+
+    if (isShellLanguage) {
+      const [firstChar] = code;
+      code = firstChar === '$' ? code.substring(2) : code;
+    }
     navigator.clipboard.writeText(code);
   }
 


### PR DESCRIPTION
Fixes #296 

- Updates `ui/src/js/07-copy-code.js` to check if the code block lang a user is copying is `shell` or one of its aliases. 
- The check will conditionally strip out the leading `$` and empty space if it's a shell block that contains `$`