### PR TITLE
fix for auth smart contract in learn documentation

### DIFF
--- a/components/learn/modules/ROOT/pages/developing-smart-contracts.adoc
+++ b/components/learn/modules/ROOT/pages/developing-smart-contracts.adoc
@@ -227,9 +227,9 @@ pragma solidity ^0.8.0;
 contract Auth {
     address private _administrator;
 
-    constructor() {
+    constructor(address deployer) {
         // Make the deployer of the contract the administrator
-        _administrator = msg.sender;
+        _administrator = deployer;
     }
 
     function isAdministrator(address user) public view returns (bool) {
@@ -254,8 +254,8 @@ contract Box {
 
     event ValueChanged(uint256 value);
 
-    constructor(Auth auth) {
-        _auth = auth;
+    constructor() {
+        _auth = new Auth(msg.sender);
     }
 
     function store(uint256 value) public {


### PR DESCRIPTION
Using solidity from version `0.8.0` I get this error with the Box and Auth Example

```sh
transact to Box.store errored: VM error: revert.

revert
	The transaction has been reverted to the initial state.
Note: The called function should be payable if you send value and the value you send should be less than your current balance.
Debug the transaction to get more information. 
```