### PR TITLE
Remove buidler clarification

### DIFF
--- a/components/learn/modules/ROOT/pages/developing-smart-contracts.adoc
+++ b/components/learn/modules/ROOT/pages/developing-smart-contracts.adoc
@@ -23,7 +23,7 @@ With that out of the way, let's get started!
 
 The first step after xref:setting-up-a-node-project#creating-a-project[creating a project] is to install a development tool.
 
-The most popular development framework for Ethereum is https://www.trufflesuite.com/truffle[Truffle] which uses https://web3js.readthedocs.io/[web3.js].  The next most popular is https://hardhat.org/[Hardhat] (previously called Buidler), and we cover its most common use with https://docs.ethers.io/[ethers.js].  Each has their strengths and it is useful to be comfortable using all of them.
+The most popular development framework for Ethereum is https://www.trufflesuite.com/truffle[Truffle] which uses https://web3js.readthedocs.io/[web3.js].  The next most popular is https://hardhat.org/[Hardhat], and we cover its most common use with https://docs.ethers.io/[ethers.js].  Each has their strengths and it is useful to be comfortable using all of them.
 
 In these guides we will show how to develop, test and deploy smart contracts using Truffle and Hardhat.  
 

--- a/components/learn/modules/ROOT/pages/developing-smart-contracts.adoc
+++ b/components/learn/modules/ROOT/pages/developing-smart-contracts.adoc
@@ -23,7 +23,7 @@ With that out of the way, let's get started!
 
 The first step after xref:setting-up-a-node-project#creating-a-project[creating a project] is to install a development tool.
 
-The most popular development framework for Ethereum is https://www.trufflesuite.com/truffle[Truffle] which uses https://web3js.readthedocs.io/[web3.js].  The next most popular is https://hardhat.org/[Hardhat], and we cover its most common use with https://docs.ethers.io/[ethers.js].  Each has their strengths and it is useful to be comfortable using all of them.
+The most popular development framework for Ethereum is https://hardhat.org/[Hardhat], and we cover its most common use with https://docs.ethers.io/[ethers.js]. The next most popular is https://www.trufflesuite.com/truffle[Truffle] which uses https://web3js.readthedocs.io/[web3.js]. Each has their strengths and it is useful to be comfortable using all of them.
 
 In these guides we will show how to develop, test and deploy smart contracts using Truffle and Hardhat.  
 


### PR DESCRIPTION
I think at this point it's not necessary anymore, but YMMV.

Also, I believe Hardhat is [more popular](https://www.npmtrends.com/hardhat-vs-truffle) than Truffle now:

![image](https://user-images.githubusercontent.com/417134/157266038-9693df5b-2524-4978-9e39-f19ed0f92834.png)
