### PR TITLE
Update correct version of get balance script

### DIFF
--- a/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
+++ b/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
@@ -177,7 +177,7 @@ We can also test the connection to the node, by querying our account balance.
 --
 [source,console]
 ----
-> (await ethers.provider.getBalance(accounts[0])).toString()
+> await web3.eth.getBalance(accounts[0])
 '0'
 ----
 --
@@ -186,7 +186,7 @@ We can also test the connection to the node, by querying our account balance.
 --
 [source,console]
 ----
-> (await ethers.provider.getBalance(accounts[0])).toString()
+> await web3.eth.getBalance(accounts[0])
 '0'
 ----
 --

--- a/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
+++ b/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
@@ -186,8 +186,8 @@ We can also test the connection to the node, by querying our account balance.
 --
 [source,console]
 ----
-> await web3.eth.getBalance(accounts[0])
-'0'
+ > (await ethers.provider.getBalance(accounts[0])).toString()
+ '0'
 ----
 --
 

--- a/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
+++ b/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
@@ -186,8 +186,8 @@ We can also test the connection to the node, by querying our account balance.
 --
 [source,console]
 ----
- > (await ethers.provider.getBalance(accounts[0])).toString()
- '0'
+> (await ethers.provider.getBalance(accounts[0])).toString()
+'0'
 ----
 --
 


### PR DESCRIPTION
Using the current version throws the following error: `eth is not defined`. While inspecting there is no `eth` variable available in the scope of the console instance. According to the following section of the documentation https://web3js.readthedocs.io/en/v1.7.3/web3-eth.html#getbalance the correct way of getting balance is as proposed.