### PR TITLE
Update available testnets after Ethereum merge

### DIFF
--- a/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
+++ b/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
@@ -20,14 +20,10 @@ include::learn::partial$hardhat-truffle-toggle.adoc[]
 There are four test networks available for you to choose, each with their own characteristics:
 
 [horizontal]
-Ropsten:: The only proof-of-work testnet. It has unpredictable block times and frequent chain reorganizations. At the same time, it is the chain that most closely resembles mainnet. (id=3)
-Rinkeby:: A proof-of-authority network. This means that new blocks are added by a set of pre-defined trusted nodes, instead of by whichever miner provides a proof-of-work. It only works with Geth clients, and has 15-second block times. (id=4)
-Kovan:: Another proof-of-authority network, but this one runs only with OpenEthereum clients, and has 4-second block times. (id=42)
-Goerli:: Also a proof-of-authority network, but compatible with both Geth and OpenEthereum clients, with 15-second block times. (id=5)
+Sepolia:: A proof-of-stake network. This means miners validators explicitly stake capital in the form of ETH into a smart contract, and acts as collateral to be destroyed of validator missbehaves. (id=11155111)
+Goerli:: Also a proof-of-stake network, compatible with both Geth and OpenEthereum clients, with 15-second block times. (id=5)
 
 NOTE: Each network is identified by a numeric ID. Local networks usually have a large random value, while id=1 is reserved for the main Ethereum network.
-
-It is up to you whether you want to test in Ropsten's unpredictable environment to assess how robust your application is, or a more reliable one to simplify the testing experience.
 
 [[connecting-project-to-network]]
 == Connecting a project to a public network
@@ -80,7 +76,7 @@ $ npm install --save-dev @truffle/hdwallet-provider
 ----
 --
 
-We need to update our configuration file with a new network connection to the testnet. Here we will use Rinkeby, but you can use whichever you want:
+We need to update our configuration file with a new network connection to the testnet. Here we will use Goerli, but you can use whichever you want:
 [.truffle]
 --
 [source,diff]
@@ -95,9 +91,9 @@ We need to update our configuration file with a new network connection to the te
      development: {
       ...
      },
-+    rinkeby: {
++    goerli: {
 +      provider: () => new HDWalletProvider(
-+        mnemonic, `https://eth-rinkeby.alchemyapi.io/v2/${alchemyApiKey}`,
++        mnemonic, `https://eth-goerli.alchemyapi.io/v2/${alchemyApiKey}`,
 +      ),
 +      network_id: 4,
 +      gasPrice: 10e9,
@@ -120,8 +116,8 @@ NOTE: See the `HDWalletProvider` https://github.com/trufflesuite/truffle/tree/ma
 ...
   module.exports = {
 +    networks: {
-+     rinkeby: {
-+       url: `https://eth-rinkeby.alchemyapi.io/v2/${alchemyApiKey}`,
++     goerli: {
++       url: `https://eth-goerli.alchemyapi.io/v2/${alchemyApiKey}`,
 +       accounts: { mnemonic: mnemonic },
 +     },
 +   },
@@ -143,14 +139,14 @@ Note in the first line that we are loading the project id and mnemonic from a `s
 
 TIP: Instead of a `secrets.json` file, you can use whatever secret-management solution you like for your project. A popular and simple option is to use https://github.com/motdotla/dotenv[`dotenv`] for injecting secrets as environment variables.
 
-We can now test out that this configuration is working by listing the accounts we have available for the Rinkeby network. Remember that yours will be different, as they depend on the mnemonic you used.
+We can now test out that this configuration is working by listing the accounts we have available for the goerli network. Remember that yours will be different, as they depend on the mnemonic you used.
 
 [.truffle]
 --
 [source,console]
 ----
-$ npx truffle console --network rinkeby
-truffle(rinkeby)> accounts
+$ npx truffle console --network goerli
+truffle(goerli)> accounts
 [ '0xEce6999C6c5BDA71d673090144b6d3bCD21d13d4',
   '0xC1310ade58A75E6d4fCb8238f9559188Ea3808f9',
 ... ]
@@ -161,7 +157,7 @@ truffle(rinkeby)> accounts
 --
 [source,console]
 ----
-$ npx hardhat console --network rinkeby
+$ npx hardhat console --network goerli
 Welcome to Node.js v12.22.1.
 Type ".help" for more information.
 > accounts = await ethers.provider.listAccounts()
@@ -196,7 +192,7 @@ Empty! This points to our next task: getting testnet funds so that we can send t
 [[finding-a-testnet-account]]
 === Funding the testnet account
 
-Most public testnets have a faucet: a site that will provide you with a small amount of test Ether for free. If you are on Rinkeby, head on to the https://faucet.rinkeby.io/[Rinkeby Authenticated Faucet] to get funds by authenticating with your Twitter or Facebook account. Alternatively, you can also use https://faucet.metamask.io/[MetaMask's faucet] to ask for funds directly to your MetaMask accounts.
+Most public testnets have a faucet: a site that will provide you with a small amount of test Ether for free. If you are on goerli, head on to the https://faucet.goerli.io/[goerli Authenticated Faucet] to get funds by authenticating with your Twitter or Facebook account. Alternatively, you can also use https://faucet.metamask.io/[MetaMask's faucet] to ask for funds directly to your MetaMask accounts.
 
 Armed with a funded account, let's deploy our contracts to the testnet!
 
@@ -209,7 +205,7 @@ With a project configured to work on a public testnet, we can now finally xref::
 --
 [source,console]
 ----
-$ npx truffle migrate --network rinkeby
+$ npx truffle migrate --network goerli
 ...
 2_deploy.js
 ===========
@@ -227,7 +223,7 @@ $ npx truffle migrate --network rinkeby
 --
 [source,console]
 ----
-$ npx hardhat run --network rinkeby scripts/deploy.js
+$ npx hardhat run --network goerli scripts/deploy.js
 Deploying Box...
 Box deployed to: 0xD7fBC6865542846e5d7236821B5e045288259cf0
 ----
@@ -235,16 +231,16 @@ Box deployed to: 0xD7fBC6865542846e5d7236821B5e045288259cf0
 
 That's it! Your `Box` contract instance will be forever stored in the testnet, and publicly accessible to anyone. 
 
-You can see your contract on a block explorer such as https://etherscan.io/[Etherscan]. Remember to access the explorer on the testnet where you deployed your contract, such as https://rinkeby.etherscan.io[rinkeby.etherscan.io] for Rinkeby.
+You can see your contract on a block explorer such as https://etherscan.io/[Etherscan]. Remember to access the explorer on the testnet where you deployed your contract, such as https://goerli.etherscan.io[goerli.etherscan.io] for goerli.
 
 [.truffle]
 --
-TIP: You can check out the contract we deployed in the example above, along with all transactions sent to it, https://rinkeby.etherscan.io/address/0xA4D767f2Fba05242502ECEcb2Ae97232F7611353[here].
+TIP: You can check out the contract we deployed in the example above, along with all transactions sent to it, https://goerli.etherscan.io/address/0xA4D767f2Fba05242502ECEcb2Ae97232F7611353[here].
 --
 
 [.hardhat]
 --
-TIP: You can check out the contract we deployed in the example above, along with all transactions sent to it, https://rinkeby.etherscan.io/address/0xD7fBC6865542846e5d7236821B5e045288259cf0[here].
+TIP: You can check out the contract we deployed in the example above, along with all transactions sent to it, https://goerli.etherscan.io/address/0xD7fBC6865542846e5d7236821B5e045288259cf0[here].
 --
 
 You can also interact with your instance as you regularly would, either using the xref::deploying-and-interacting.adoc#interacting-from-the-console[console], or xref::deploying-and-interacting.adoc#interacting-programatically[programmatically].
@@ -252,14 +248,14 @@ You can also interact with your instance as you regularly would, either using th
 [.truffle]
 --
 ```console
-$ npx truffle console --network rinkeby
-truffle(rinkeby)> box = await Box.deployed()
+$ npx truffle console --network goerli
+truffle(goerli)> box = await Box.deployed()
 undefined
-truffle(rinkeby)> await box.store(42)
+truffle(goerli)> await box.store(42)
 { tx:
    '0x7d1a556b34fcb26855c6646669fc926738b05589591de6c7bb1f8773546817e7',
 ...
-truffle(rinkeby)> (await box.retrieve()).toString()
+truffle(goerli)> (await box.retrieve()).toString()
 '42'
 ```
 --
@@ -267,7 +263,7 @@ truffle(rinkeby)> (await box.retrieve()).toString()
 [.hardhat]
 --
 ```console
-$ npx hardhat console --network rinkeby
+$ npx hardhat console --network goerli
 Welcome to Node.js v12.22.1.
 Type ".help" for more information.
 > const Box = await ethers.getContractFactory('Box');

--- a/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
+++ b/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
@@ -95,7 +95,7 @@ We need to update our configuration file with a new network connection to the te
 +      provider: () => new HDWalletProvider(
 +        mnemonic, `https://eth-goerli.alchemyapi.io/v2/${alchemyApiKey}`,
 +      ),
-+      network_id: 4,
++      network_id: 5,
 +      gasPrice: 10e9,
 +      skipDryRun: true,
 +    },

--- a/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
+++ b/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
@@ -20,7 +20,7 @@ include::learn::partial$hardhat-truffle-toggle.adoc[]
 There are two test networks available for you to choose, each with their own characteristics:
 
 [horizontal]
-Sepolia:: A proof-of-stake network. This means miners validators explicitly stake capital in the form of ETH into a smart contract, and acts as collateral to be destroyed of validator missbehaves. (id=11155111)
+Sepolia:: A proof-of-stake network. This means validators explicitly stake capital in the form of ETH into a smart contract, which acts as collateral to be destroyed upon misbehavior. (id=11155111)
 Goerli:: Also a proof-of-stake network, compatible with both Geth and OpenEthereum clients, with 15-second block times. (id=5)
 
 NOTE: Each network is identified by a numeric ID. Local networks usually have a large random value, while id=1 is reserved for the main Ethereum network.

--- a/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
+++ b/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
@@ -17,7 +17,7 @@ include::learn::partial$hardhat-truffle-toggle.adoc[]
 [[testnet-list]]
 == Available testnets
 
-There are four test networks available for you to choose, each with their own characteristics:
+There are two test networks available for you to choose, each with their own characteristics:
 
 [horizontal]
 Sepolia:: A proof-of-stake network. This means miners validators explicitly stake capital in the form of ETH into a smart contract, and acts as collateral to be destroyed of validator missbehaves. (id=11155111)

--- a/components/learn/modules/ROOT/pages/deploying-and-interacting.adoc
+++ b/components/learn/modules/ROOT/pages/deploying-and-interacting.adoc
@@ -16,7 +16,7 @@ include::learn::partial$hardhat-truffle-toggle.adoc[]
 
 Before we begin, we first need an environment where we can deploy our contracts. The Ethereum blockchain (often called "mainnet", for "main network") requires spending real money to use it, in the form of Ether (its native currency). This makes it a poor choice when trying out new ideas or tools.
 
-To solve this, a number of "testnets" (for "test networks") exist: these include the Ropsten, Rinkeby, Kovan and Goerli blockchains. They work very similarly to mainnet, with one difference: you can get Ether for these networks for free, so that using them doesn't cost you a single cent. However, you will still need to deal with private key management, blocktimes in the range of 5 to 20 seconds, and actually getting this free Ether.
+To solve this, a number of "testnets" (for "test networks") exist: these include the Sepolia, and Goerli blockchains. They work very similarly to mainnet, with one difference: you can get Ether for these networks for free, so that using them doesn't cost you a single cent. However, you will still need to deal with private key management, blocktimes in the range of 5 to 20 seconds, and actually getting this free Ether.
 
 During development, it is a better idea to instead use a _local_ blockchain. It runs on your machine, requires no Internet access, provides you with all the Ether that you need, and mines blocks instantly. These reasons also make local blockchains a great fit for xref:writing-automated-tests.adoc#setting-up-a-testing-environment[automated tests].
 

--- a/components/learn/modules/ROOT/pages/sending-gasless-transactions.adoc
+++ b/components/learn/modules/ROOT/pages/sending-gasless-transactions.adoc
@@ -156,7 +156,7 @@ All contracts are up to date
 ✓ Instance created at 0xCfEB869F69431e42cdB54A4F4f105C19C080A601
 ----
 
-Great! Now, if we deployed this contract to mainnet or the rinkeby testnet, we would be almost ready to start sending gasless transactions to it, since the GSN is already set up on both of those networks. However, since we are on a local ganache, we'll need to set it up ourselves.
+Great! Now, if we deployed this contract to mainnet or the goerli testnet, we would be almost ready to start sending gasless transactions to it, since the GSN is already set up on both of those networks. However, since we are on a local ganache, we'll need to set it up ourselves.
 
 [[deploying-local-gsn]]
 === Deploying a Local GSN for Development
@@ -298,18 +298,18 @@ Great! We can now fire up our application running `npm start` from within the `c
 [[moving-to-testnet]]
 === Moving to a Testnet
 
-It is not very impressive to send a local transaction in your ganache network, where you already have a bunch of fully-funded accounts. To witness the GSN at its full potential, let's move our application to the Rinkeby testnet. If you later want to go onto mainnet, the instructions are the same.
+It is not very impressive to send a local transaction in your ganache network, where you already have a bunch of fully-funded accounts. To witness the GSN at its full potential, let's move our application to the goerli testnet. If you later want to go onto mainnet, the instructions are the same.
 
-You will need to create a new entry in the `networks.js` file, with a Rinkeby account that has been funded. For detailed instructions on how to do this, check out xref:connecting-to-public-test-networks.adoc[Deploying to Public Tests Network].
+You will need to create a new entry in the `networks.js` file, with a goerli account that has been funded. For detailed instructions on how to do this, check out xref:connecting-to-public-test-networks.adoc[Deploying to Public Tests Network].
 
-We can now deploy our `Counter` contract to Rinkeby:
+We can now deploy our `Counter` contract to goerli:
 
 [source,console]
 ----
 $ openzeppelin create
 ✓ Compiled contracts with solc 0.5.9 (commit.e560f70d)
 ? Pick a contract to instantiate: Counter
-? Pick a network: rinkeby
+? Pick a network: goerli
 ✓ Added contract Counter
 ✓ Contract Counter deployed
 ? Call a function to initialize the instance after creating it?: Yes
@@ -319,7 +319,7 @@ $ openzeppelin create
 ----
 
 
-The next step will be to instruct our (d)app to connect to a Rinkeby node instead of the local network. Change the `PROVIDER_URL` in your `App.js` to, for example, an Infura Rinkeby endpoint.
+The next step will be to instruct our (d)app to connect to a goerli node instead of the local network. Change the `PROVIDER_URL` in your `App.js` to, for example, an Infura goerli endpoint.
 
 We will now be using a real GSN provider rather than our developer environment, so you may want to also provide a xref:gsn-provider::api.adoc[configuration object], which will give you more control over things such as the gas price you are willing to pay. For production (d)apps, you will want to configure this to your requirements.
 
@@ -328,17 +328,17 @@ We will now be using a real GSN provider rather than our developer environment, 
 import { useWeb3Network, useEphemeralKey } from "@openzeppelin/network/react";
 
 // inside App.js#App()
-const context = useWeb3Network('https://rinkeby.infura.io/v3/' + INFURA_API_TOKEN, {
+const context = useWeb3Network('https://goerli.infura.io/v3/' + INFURA_API_TOKEN, {
   gsn: { signKey: useEphemeralKey() }
 });
 ----
 
 
-We are almost there! If you try to use your (d)app now, you will notice that you are not able to send any transactions. This is because your `Counter` contract has not been funded on this network yet. Instead of using the `oz-gsn fund-recipient` command we used earlier, we will now use the https://gsn.openzeppelin.com[online gsn-tool] by pasting in the address of your instance. To do this, the web interface requires that you use MetaMask on the Rinkeby Network, which will allow you to deposit funds into your contract.
+We are almost there! If you try to use your (d)app now, you will notice that you are not able to send any transactions. This is because your `Counter` contract has not been funded on this network yet. Instead of using the `oz-gsn fund-recipient` command we used earlier, we will now use the https://gsn.openzeppelin.com[online gsn-tool] by pasting in the address of your instance. To do this, the web interface requires that you use MetaMask on the goerli Network, which will allow you to deposit funds into your contract.
 
 image::GSNDappTool.png[OpenZeppelin GSN Dapp Tool,500]
 
-That's it! We can now start sending transactions to our `Counter` contract on the Rinkeby network from our browser without even having MetaMask installed.
+That's it! We can now start sending transactions to our `Counter` contract on the goerli network from our browser without even having MetaMask installed.
 
 [[gsn-kit]]
 == The GSN Starter Kit


### PR DESCRIPTION
After the merge on June 2022, Ethereum deprecated several testnets, Rinkeby, Kovan and Ropten, and introduced a new one, Sepolia, this PR introduces information about the new testnets and removes deprecated testnet according to [this documentation](https://ethereum.org/en/developers/docs/networks/#ethereum-testnets).

Note: Sepolia should be temporary, so this will need to be updated after that happens.