### PR TITLE
Add Sepolia Testnet ETH faucet

### DIFF
--- a/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
+++ b/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
@@ -193,6 +193,7 @@ Empty! This points to our next task: getting testnet funds so that we can send t
 === Funding the testnet account
 
 Most public testnets have a faucet: a site that will provide you with a small amount of test Ether for free. If you are on goerli, head to the https://goerlifaucet.com[Alchemy's free Goerli faucet] to get free testETH. Alternatively, you can also use https://faucet.metamask.io/[MetaMask's faucet] to ask for funds directly to your MetaMask accounts.
+ If you need test Ether on Sepolia, you can use https://www.infura.io/faucet[Infura's free Sepolia faucet] to get free testETH.
 
 Armed with a funded account, let's deploy our contracts to the testnet!
 

--- a/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
+++ b/components/learn/modules/ROOT/pages/connecting-to-public-test-networks.adoc
@@ -193,7 +193,7 @@ Empty! This points to our next task: getting testnet funds so that we can send t
 === Funding the testnet account
 
 Most public testnets have a faucet: a site that will provide you with a small amount of test Ether for free. If you are on goerli, head to the https://goerlifaucet.com[Alchemy's free Goerli faucet] to get free testETH. Alternatively, you can also use https://faucet.metamask.io/[MetaMask's faucet] to ask for funds directly to your MetaMask accounts.
- If you need test Ether on Sepolia, you can use https://www.infura.io/faucet[Infura's free Sepolia faucet] to get free testETH.
+If you need test Ether on Sepolia, you can use https://www.infura.io/faucet[Infura's free Sepolia faucet] to get free testETH.
 
 Armed with a funded account, let's deploy our contracts to the testnet!
 


### PR DESCRIPTION
Infura just released a Sepolia Testnet Faucet that lets you claim 0.5 Sepolia ETH per day, for free. It's super easy to use, just visit http://infura.io/faucet, sign in to your Infura account, enter your wallet address, and claim.

Sepolia Testnet is an important tool for testing your smart contracts before deploying them on mainnet environments. With our Testnet Faucet, you can easily catch bugs and reduce the cost of deploying tests on mainnet.

At Infura, we're all about making Web3 development easy and reliable. That's why we're excited to offer this important tool to help you achieve your goals.