### PR TITLE
add platform-docs routing

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -74,6 +74,10 @@ content:
     - url: https://github.com/OpenZeppelin/nile
       branches: release-v*
       start_path: docs
+
+    - url: https://github.com/OpenZeppelin/platform-docs
+      branches: HEAD
+      start_path: docs
 ui:
   bundle:
     url: ./ui/theme


### PR DESCRIPTION
Adding routing for platform-docs per instructions at https://github.com/OpenZeppelin/docs.openzeppelin.com#readme