### PR TITLE
Defender v2 redirects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+.vscode
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/_redirects
+++ b/_redirects
@@ -97,3 +97,8 @@ https://openzeppelin-docs.netlify.com/* https://docs.openzeppelin.com/:splat 301
 /upgrades-plugins/api-buidler-upgrades /upgrades-plugins/api-hardhat-upgrades 301
 /upgrades-plugins/1.x/buidler-upgrades /upgrades-plugins/1.x/hardhat-upgrades 301
 /upgrades-plugins/1.x/api-buidler-upgrades /upgrades-plugins/1.x/api-hardhat-upgrades 301
+
+# Defender V2 -> Netlify
+/defender/v2 https://platform-docs-beta.netlify.app/platform/beta/ 301
+/defender/v2/* https://platform-docs-beta.netlify.app/platform/beta/:splat 301
+


### PR DESCRIPTION
- Redirect defender v2 docs.openzeppelin.com/defender/v2 to netlify app.