### PR TITLE
Add root redirection rule for Defender docs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -100,3 +100,4 @@ https://openzeppelin-docs.netlify.com/* https://docs.openzeppelin.com/:splat 301
 
 # Defender V2 -> Netlify
 /defender/v2/* https://docs-v2--openzeppelin-defender.netlify.app/defender/v2/:splat 302
+/defender/v2 https://docs-v2--openzeppelin-defender.netlify.app/defender/v2 302


### PR DESCRIPTION
This PR will add an additional redirect so that the Defender docs are accessible from the root domain. 
Currently, only links to specific pages are working. 