### PR TITLE
Add ability to configure sidebar to be collapsed by default

### DIFF
--- a/ui/preview/build.js
+++ b/ui/preview/build.js
@@ -96,7 +96,7 @@ async function getUIModel() {
   const makeModel = page => {
     const [componentName, ...componentPage] = page.relativeSrcPath.split(path.sep);
     const component = model.site.components[componentName] ?? model.site.components.ROOT;
-    const url = path.join(componentName, ...componentPage)
+    const url = path.join('/', componentName, ...componentPage)
       .replace(path.extname(page.relativeSrcPath), '.html');
     const siteRootPath = path.relative(page.relativeSrcPath, '');
     const siteRootUrl = path.join(siteRootPath, 'index.html');

--- a/ui/src/css/specific/navigation.scss
+++ b/ui/src/css/specific/navigation.scss
@@ -110,7 +110,7 @@ button.collapse-toggle {
 }
 
 /* Collapse by default before JS runs and control is handed over to JS */
-body.collapse-default .nav-collapse-preinit .nav-li:not(.nav-li-active-parent) > button.collapse-toggle ~ .collapsible-content {
+body.sidebar-collapse-default .nav-collapse-preinit .nav-li:not(.nav-li-active-parent) > button.collapse-toggle ~ .collapsible-content {
   display: none;
 }
 

--- a/ui/src/css/specific/navigation.scss
+++ b/ui/src/css/specific/navigation.scss
@@ -6,10 +6,10 @@
   a {
     text-decoration: none;
     color: inherit;
+  }
 
-    &.nav-link-active {
-      color: var(--core-violet-4);
-    }
+  .nav-li-active > a {
+    color: var(--core-violet-4);
   }
 }
 
@@ -93,18 +93,25 @@
   opacity: .8;
 }
 
-button.collapse-toggle{
+button.collapse-toggle {
   cursor: pointer;
   padding: 0;
   border: none;
 
-  &.active ~ .collapsible-content {
-  display: none;
+  &.toggled {
+    img {
+      transform: rotate(-90deg);
+    }
+
+    ~ .collapsible-content {
+      display: none;
+    }
   }
 }
 
-.collapse-toggle.active img{
-  transform: rotate(-90deg);
+/* Collapse by default before JS runs and control is handed over to JS */
+body.collapse-default .nav-collapse-preinit .nav-li:not(.nav-li-active-parent) > button.collapse-toggle ~ .collapsible-content {
+  display: none;
 }
 
 .close-menu-btn {

--- a/ui/src/js/05-sidr-menu.js
+++ b/ui/src/js/05-sidr-menu.js
@@ -7,18 +7,25 @@
   const closeMenuButton = document.querySelector('.close-menu-btn');
 
   sidrToggle.addEventListener('click', function (e) {
-    sidrPanel.classList.toggle('active');
+    sidrPanel.classList.toggle('toggled');
   });
 
   closeMenuButton.addEventListener('click', function (e) {
-    sidrPanel.classList.toggle('active');
+    sidrPanel.classList.toggle('toggled');
   });
 
+  const isDefaultCollapsed = document.body.classList.contains('collapse-default');
   const collapseToggles = document.querySelectorAll('.collapse-toggle');
 
   collapseToggles.forEach(function (o) {
+    if (isDefaultCollapsed && !o.parentElement.classList.contains('nav-li-active-parent')) {
+      o.classList.toggle('toggled');
+    }
     o.addEventListener('click', function (e) {
-      this.classList.toggle('active');
+      this.classList.toggle('toggled');
     });
   });
+
+  // The preinit class sets up collapsed states before JS executes to avoid flashing uncollapsed menu
+  document.querySelector('.nav-collapse-preinit')?.classList.toggle('nav-collapse-preinit');
 })();

--- a/ui/src/js/05-sidr-menu.js
+++ b/ui/src/js/05-sidr-menu.js
@@ -27,5 +27,5 @@
   });
 
   // The preinit class sets up collapsed states before JS executes to avoid flashing uncollapsed menu
-  document.querySelector('.nav-collapse-preinit')?.classList.toggle('nav-collapse-preinit');
+  document.querySelector('.nav-collapse-preinit')?.classList.remove('nav-collapse-preinit');
 })();

--- a/ui/src/js/05-sidr-menu.js
+++ b/ui/src/js/05-sidr-menu.js
@@ -14,7 +14,7 @@
     sidrPanel.classList.toggle('toggled');
   });
 
-  const isDefaultCollapsed = document.body.classList.contains('collapse-default');
+  const isDefaultCollapsed = document.body.classList.contains('sidebar-collapse-default');
   const collapseToggles = document.querySelectorAll('.collapse-toggle');
 
   collapseToggles.forEach(function (o) {

--- a/ui/theme/helpers/attribute-classes.js
+++ b/ui/theme/helpers/attribute-classes.js
@@ -1,0 +1,3 @@
+module.exports = function (attrs) {
+  return attrs.split(',').filter(a => a in this.page.attributes).join(' ');
+}

--- a/ui/theme/helpers/child-is-active.js
+++ b/ui/theme/helpers/child-is-active.js
@@ -1,0 +1,3 @@
+module.exports = function childIsActive(opts) {
+  return this.url === opts.data.root.page.url || this.items?.some(i => childIsActive.call(i, opts));
+}

--- a/ui/theme/partials/layout.hbs
+++ b/ui/theme/partials/layout.hbs
@@ -29,7 +29,7 @@
     <link rel="icon" type="image/png" sizes="192x192"  href="{{@root.site.ui.url}}/images/favicon-192x192.png"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono:400,500,700&display=swap"/>
   </head>
-  <body class="{{#if (in 'notoc' page.attributes)}}notoc{{/if}}">
+  <body class="{{attribute-classes 'notoc,collapse-default'}}">
     {{> scripts-top}}
     {{> icons}}
     {{> main}}

--- a/ui/theme/partials/layout.hbs
+++ b/ui/theme/partials/layout.hbs
@@ -29,7 +29,7 @@
     <link rel="icon" type="image/png" sizes="192x192"  href="{{@root.site.ui.url}}/images/favicon-192x192.png"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono:400,500,700&display=swap"/>
   </head>
-  <body class="{{attribute-classes 'notoc,collapse-default'}}">
+  <body class="{{attribute-classes 'notoc,sidebar-collapse-default'}}">
     {{> scripts-top}}
     {{> icons}}
     {{> main}}

--- a/ui/theme/partials/navigation-tree.hbs
+++ b/ui/theme/partials/navigation-tree.hbs
@@ -1,9 +1,9 @@
 {{#each items}}
 {{#if content}}
-<li class="nav-li" {{#if currentPath}}data-state="expanded"{{/if}}>
+<li class="nav-li {{#if (eq url @root.page.url)}}nav-li-active{{/if}} {{#if (child-is-active)}}nav-li-active-parent{{/if}}">
   {{#if items}}<button class="collapse-toggle"><img src="{{@root.site.ui.url}}/images/icons/arrow.svg"></button>{{/if}}
   {{#if url}}
-  <a class="link nav-link{{#if (eq url @root.page.url)}} nav-link-active{{/if}}" href="{{{url}}}">
+  <a class="link nav-link" href="{{{url}}}">
     {{{content}}}
   </a>
   {{else}}

--- a/ui/theme/partials/navigation.hbs
+++ b/ui/theme/partials/navigation.hbs
@@ -1,4 +1,4 @@
-<nav id="sidr" class="nav" data-component="{{@root.page.component.name}}" data-is-home="{{home}}"
+<nav id="sidr" class="nav nav-collapse-preinit" data-component="{{@root.page.component.name}}" data-is-home="{{home}}"
   data-is-site-aspect="{{component.siteAspect}}" data-version="{{component.version.string}}" role="navigation">
   <button class="close-menu-btn">
     <svg style="width:24px;height:24px" viewBox="0 0 24 24">


### PR DESCRIPTION
Sub-sites will be able to configure the sidebar to appear collapsed by default by defining a [component attribute](https://docs.antora.org/antora/latest/component-attributes/) in `antora.yml`:


```yaml
asciidoc: 
  attributes:
    page-sidebar-collapse-default: true
```

CC @ericnordelo 