### PR TITLE
Add ability to collapse sections by default separately

### DIFF
--- a/ui/theme/helpers/section-collapsed.js
+++ b/ui/theme/helpers/section-collapsed.js
@@ -1,0 +1,4 @@
+module.exports = function (section, opts) {
+  const collapse = opts.data.root.page.attributes['sidebar-collapse-default'];
+  return typeof collapse === 'string' ? collapse.split(/\s*,\s*/).includes(section) : !!collapse;
+}

--- a/ui/theme/partials/layout.hbs
+++ b/ui/theme/partials/layout.hbs
@@ -29,7 +29,7 @@
     <link rel="icon" type="image/png" sizes="192x192"  href="{{@root.site.ui.url}}/images/favicon-192x192.png"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono:400,500,700&display=swap"/>
   </head>
-  <body class="{{page-attribute-classes 'notoc,sidebar-collapse-default'}}">
+  <body class="{{page-attribute-classes 'notoc'}}">
     {{> scripts-top}}
     {{> icons}}
     {{> main}}

--- a/ui/theme/partials/navigation-tree.hbs
+++ b/ui/theme/partials/navigation-tree.hbs
@@ -2,7 +2,7 @@
 {{#if content}}
 <li class="nav-li {{#if (eq url @root.page.url)}}nav-li-active{{/if}}">
   {{#if items}}
-  <button class="collapse-toggle {{#if (page-has-attribute 'sidebar-collapse-default')}}{{#unless (child-is-active)}}toggled{{/unless}}{{/if}}">
+  <button class="collapse-toggle {{#if (section-collapsed content)}}{{#unless (child-is-active)}}toggled{{/unless}}{{/if}}">
     <img src="{{@root.site.ui.url}}/images/icons/arrow.svg">
   </button>
   {{/if}}


### PR DESCRIPTION
It's now possible to choose specific sections in the sidebar navigation that should be collapsed by default, as opposed to all sections.

In `antora.yml` for the component, set the attribute `page-sidebar-collapse-default` to a string of comma-separated navigation sections:

```yml
asciidoc: 
  attributes:
    page-sidebar-collapse-default: 'Tutorials,Other'
```

If `nav.adoc` looks like below, only the Tutorials section will start collapsed.

```asciidoc
* xref:index.adoc[Overview]

.Reference
* xref:javascript.adoc[JavaScript]
* xref:perl.adoc[Perl]

.Tutorials
* xref:a-tutorial.adoc[A Tutorial]
* xref:another-tutorial.adoc[Another Tutorial]
```

CC @cairoeth 