### PR TITLE
Update netlify.toml to add CSP header

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -32,4 +32,4 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "script-src 'self' *.googletagmanager.com *.cloudfront.net js.hs-scripts.com;"
+    Content-Security-Policy = "script-src 'self' *.googletagmanager.com *.cloudfront.net js.hs-scripts.com *.openzeppelin.com *.netlify.app js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com;"

--- a/netlify.toml
+++ b/netlify.toml
@@ -32,4 +32,4 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "script-src 'self' *.googletagmanager.com *.cloudfront.net js.hs-scripts.com js.hsadspixel.net js.hsleadflows.net *.openzeppelin.com *.netlify.app js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com;"
+    Content-Security-Policy = "script-src 'self' *.googletagmanager.com *.cloudfront.net js.hs-scripts.com js.hsadspixel.net js.hsleadflows.net wizard.openzeppelin.com js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com;"

--- a/netlify.toml
+++ b/netlify.toml
@@ -28,8 +28,3 @@
   from = "/sdk/2.6/*"
   to = "/sdk/:splat"
   status = 302
-
-[[headers]]
-  for = "/*"
-  [headers.values]
-    Content-Security-Policy = "script-src 'self' *.googletagmanager.com *.cloudfront.net js.hs-scripts.com js.hsadspixel.net js.hsleadflows.net wizard.openzeppelin.com js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com;"

--- a/netlify.toml
+++ b/netlify.toml
@@ -32,4 +32,4 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "script-src 'self' *.googletagmanager.com *.cloudfront.net js.hs-scripts.com *.openzeppelin.com *.netlify.app js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com;"
+    Content-Security-Policy = "script-src 'self' *.googletagmanager.com *.cloudfront.net js.hs-scripts.com js.hsadspixel.net js.hsleadflows.net *.openzeppelin.com *.netlify.app js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com;"

--- a/netlify.toml
+++ b/netlify.toml
@@ -28,3 +28,8 @@
   from = "/sdk/2.6/*"
   to = "/sdk/:splat"
   status = 302
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "script-src 'self' *.googletagmanager.com *.cloudfront.net js.hs-scripts.com;"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,3 +28,7 @@ antora --stacktrace "$@"
 ## Redirections
 
 node scripts/latest-redirects.js
+
+## Headers
+
+sh scripts/custom_headers.sh

--- a/scripts/custom_headers.sh
+++ b/scripts/custom_headers.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+buildDir='build/site'
+
+input_text="/*
+  Content-Security-Policy = \"script-src 'self' *.googletagmanager.com $NETLIFY_IMAGES_CDN_DOMAIN js.hs-scripts.com js.hsadspixel.net js.hsleadflows.net js.hsleadflows.net js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com;\""
+
+echo "$input_text" > "$buildDir/_headers"
+
+echo "Content-Security-Policy updated and saved to _headers file."

--- a/scripts/custom_headers.sh
+++ b/scripts/custom_headers.sh
@@ -5,7 +5,7 @@
 buildDir='build/site'
 
 input_text="/*
-  Content-Security-Policy: script-src 'self' *.googletagmanager.com $NETLIFY_IMAGES_CDN_DOMAIN js.hs-scripts.com js.hsadspixel.net js.hsleadflows.net js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com no-cache.hubspot.com *.hs-sites.com static.hsappstatic.net *.usemessages.com *.hubspotusercontent00.net *.hubspot.net play.hubspotvideo.com cdn2.hubspot.net *.hscollectedforms.net *.hsleadflows.net *.hsforms.net *.hsforms.com *.hs-scripts.com *.hubspotfeedback.com feedback.hubapi.com;"
+  Content-Security-Policy: script-src 'self' www.googletagmanager.com $NETLIFY_IMAGES_CDN_DOMAIN js.hs-scripts.com js.hsadspixel.net js.hsleadflows.net js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com no-cache.hubspot.com *.hs-sites.com static.hsappstatic.net *.usemessages.com *.hubspotusercontent00.net *.hubspot.net play.hubspotvideo.com cdn2.hubspot.net *.hscollectedforms.net *.hsleadflows.net *.hsforms.net *.hsforms.com *.hs-scripts.com *.hubspotfeedback.com feedback.hubapi.com;"
 
 echo "$input_text" > "$buildDir/_headers"
 

--- a/scripts/custom_headers.sh
+++ b/scripts/custom_headers.sh
@@ -2,11 +2,11 @@
 
 # This script will create a custom _headers file with security headers. Ref. for the CSP header: https://content-security-policy.com/examples/netlify/
 
-buildDir='build/site'
+build_dir='build/site'
 
 input_text="/*
   Content-Security-Policy: script-src 'self' 'unsafe-inline' wizard.openzeppelin.com www.googletagmanager.com $NETLIFY_IMAGES_CDN_DOMAIN js.hs-scripts.com netlify-cdp-loader.netlify.app js.hsadspixel.net js.hsleadflows.net js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com no-cache.hubspot.com *.hs-sites.com static.hsappstatic.net *.usemessages.com *.hubspotusercontent00.net *.hubspot.net play.hubspotvideo.com cdn2.hubspot.net *.hscollectedforms.net *.hsleadflows.net *.hsforms.net *.hsforms.com *.hs-scripts.com *.hubspotfeedback.com feedback.hubapi.com;"
 
-echo "$input_text" > "$buildDir/_headers"
+echo "$input_text" > "$build_dir/_headers"
 
 echo "Content-Security-Policy updated and saved to _headers file."

--- a/scripts/custom_headers.sh
+++ b/scripts/custom_headers.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env sh
 
+# This script will create a custom _headers file with security headers. Ref. for the CSP header: https://content-security-policy.com/examples/netlify/
+
 buildDir='build/site'
 
 input_text="/*
-  Content-Security-Policy = \"script-src 'self' *.googletagmanager.com $NETLIFY_IMAGES_CDN_DOMAIN js.hs-scripts.com js.hsadspixel.net js.hsleadflows.net js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com no-cache.hubspot.com *.hs-sites.com static.hsappstatic.net *.usemessages.com *.hubspotusercontent00.net *.hubspot.net play.hubspotvideo.com cdn2.hubspot.net *.hscollectedforms.net *.hsleadflows.net *.hsforms.net *.hsforms.com *.hs-scripts.com *.hubspotfeedback.com feedback.hubapi.com;\""
+  Content-Security-Policy: \"script-src 'self' *.googletagmanager.com $NETLIFY_IMAGES_CDN_DOMAIN js.hs-scripts.com js.hsadspixel.net js.hsleadflows.net js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com no-cache.hubspot.com *.hs-sites.com static.hsappstatic.net *.usemessages.com *.hubspotusercontent00.net *.hubspot.net play.hubspotvideo.com cdn2.hubspot.net *.hscollectedforms.net *.hsleadflows.net *.hsforms.net *.hsforms.com *.hs-scripts.com *.hubspotfeedback.com feedback.hubapi.com;\""
 
 echo "$input_text" > "$buildDir/_headers"
 

--- a/scripts/custom_headers.sh
+++ b/scripts/custom_headers.sh
@@ -5,7 +5,7 @@
 buildDir='build/site'
 
 input_text="/*
-  Content-Security-Policy: script-src 'self' www.googletagmanager.com $NETLIFY_IMAGES_CDN_DOMAIN js.hs-scripts.com js.hsadspixel.net js.hsleadflows.net js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com no-cache.hubspot.com *.hs-sites.com static.hsappstatic.net *.usemessages.com *.hubspotusercontent00.net *.hubspot.net play.hubspotvideo.com cdn2.hubspot.net *.hscollectedforms.net *.hsleadflows.net *.hsforms.net *.hsforms.com *.hs-scripts.com *.hubspotfeedback.com feedback.hubapi.com;"
+  Content-Security-Policy: script-src 'self' 'unsafe-inline' www.googletagmanager.com $NETLIFY_IMAGES_CDN_DOMAIN js.hs-scripts.com netlify-cdp-loader.netlify.app js.hsadspixel.net js.hsleadflows.net js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com no-cache.hubspot.com *.hs-sites.com static.hsappstatic.net *.usemessages.com *.hubspotusercontent00.net *.hubspot.net play.hubspotvideo.com cdn2.hubspot.net *.hscollectedforms.net *.hsleadflows.net *.hsforms.net *.hsforms.com *.hs-scripts.com *.hubspotfeedback.com feedback.hubapi.com;"
 
 echo "$input_text" > "$buildDir/_headers"
 

--- a/scripts/custom_headers.sh
+++ b/scripts/custom_headers.sh
@@ -5,7 +5,7 @@
 buildDir='build/site'
 
 input_text="/*
-  Content-Security-Policy: script-src 'self' 'unsafe-inline' www.googletagmanager.com $NETLIFY_IMAGES_CDN_DOMAIN js.hs-scripts.com netlify-cdp-loader.netlify.app js.hsadspixel.net js.hsleadflows.net js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com no-cache.hubspot.com *.hs-sites.com static.hsappstatic.net *.usemessages.com *.hubspotusercontent00.net *.hubspot.net play.hubspotvideo.com cdn2.hubspot.net *.hscollectedforms.net *.hsleadflows.net *.hsforms.net *.hsforms.com *.hs-scripts.com *.hubspotfeedback.com feedback.hubapi.com;"
+  Content-Security-Policy: script-src 'self' 'unsafe-inline' wizard.openzeppelin.com www.googletagmanager.com $NETLIFY_IMAGES_CDN_DOMAIN js.hs-scripts.com netlify-cdp-loader.netlify.app js.hsadspixel.net js.hsleadflows.net js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com no-cache.hubspot.com *.hs-sites.com static.hsappstatic.net *.usemessages.com *.hubspotusercontent00.net *.hubspot.net play.hubspotvideo.com cdn2.hubspot.net *.hscollectedforms.net *.hsleadflows.net *.hsforms.net *.hsforms.com *.hs-scripts.com *.hubspotfeedback.com feedback.hubapi.com;"
 
 echo "$input_text" > "$buildDir/_headers"
 

--- a/scripts/custom_headers.sh
+++ b/scripts/custom_headers.sh
@@ -3,7 +3,7 @@
 buildDir='build/site'
 
 input_text="/*
-  Content-Security-Policy = \"script-src 'self' *.googletagmanager.com $NETLIFY_IMAGES_CDN_DOMAIN js.hs-scripts.com js.hsadspixel.net js.hsleadflows.net js.hsleadflows.net js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com;\""
+  Content-Security-Policy = \"script-src 'self' *.googletagmanager.com $NETLIFY_IMAGES_CDN_DOMAIN js.hs-scripts.com js.hsadspixel.net js.hsleadflows.net js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com no-cache.hubspot.com *.hs-sites.com static.hsappstatic.net *.usemessages.com *.hubspotusercontent00.net *.hubspot.net play.hubspotvideo.com cdn2.hubspot.net *.hscollectedforms.net *.hsleadflows.net *.hsforms.net *.hsforms.com *.hs-scripts.com *.hubspotfeedback.com feedback.hubapi.com;\""
 
 echo "$input_text" > "$buildDir/_headers"
 

--- a/scripts/custom_headers.sh
+++ b/scripts/custom_headers.sh
@@ -5,7 +5,7 @@
 buildDir='build/site'
 
 input_text="/*
-  Content-Security-Policy: \"script-src 'self' *.googletagmanager.com $NETLIFY_IMAGES_CDN_DOMAIN js.hs-scripts.com js.hsadspixel.net js.hsleadflows.net js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com no-cache.hubspot.com *.hs-sites.com static.hsappstatic.net *.usemessages.com *.hubspotusercontent00.net *.hubspot.net play.hubspotvideo.com cdn2.hubspot.net *.hscollectedforms.net *.hsleadflows.net *.hsforms.net *.hsforms.com *.hs-scripts.com *.hubspotfeedback.com feedback.hubapi.com;\""
+  Content-Security-Policy: script-src 'self' *.googletagmanager.com $NETLIFY_IMAGES_CDN_DOMAIN js.hs-scripts.com js.hsadspixel.net js.hsleadflows.net js.hs-analytics.net js.hubspot.com js.headleadflows.net js.hscollectedforms.net js.hs-banner.com no-cache.hubspot.com *.hs-sites.com static.hsappstatic.net *.usemessages.com *.hubspotusercontent00.net *.hubspot.net play.hubspotvideo.com cdn2.hubspot.net *.hscollectedforms.net *.hsleadflows.net *.hsforms.net *.hsforms.com *.hs-scripts.com *.hubspotfeedback.com feedback.hubapi.com;"
 
 echo "$input_text" > "$buildDir/_headers"
 


### PR DESCRIPTION
This PR is part of our efforts to add security headers to most of our websites. The Content Security Policy (CSP) delimits the domains from which our website can load resources (such as JS files, images, etc.).

The following values will be added to the netlify.toml file:
```
[[headers]]
  for = "/*"
  [headers.values]
    Content-Security-Policy = "script-src 'self' *.googletagmanager.com *.cloudfront.net js.hs-scripts.com;"
```

References:
https://content-security-policy.com/examples/netlify/
https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP