### PR TITLE
Add Contracts for Cairo to home

### DIFF
--- a/components/home/modules/ROOT/pages/index.adoc
+++ b/components/home/modules/ROOT/pages/index.adoc
@@ -22,9 +22,9 @@ xref:upgrades.adoc[[.card-title]#Upgrades# [.card-body]#pass:q[A comprehensive s
 xref:defender::index.adoc[[.card-title]#Defender# [.card-body]#pass:q[A secure platform to automate Ethereum operations.]#]
 --
 
-[.card.card-secondary.card-test-helpers]
+[.card.card-secondary.card-contracts-cairo]
 --
-xref:test-helpers::index.adoc[[.card-title]#Test Helpers# [.card-body]#pass:q[A JavaScript library of common assertions for testing smart contracts.]#]
+xref:contracts-cairo::index.adoc[[.card-title]#Contracts for Cairo# [.card-body]#pass:q[A library for secure smart contract development written in Cairo for Starknet.]#]
 --
 
 [.card.card-secondary.card-solidity-docgen]

--- a/ui/src/css/components/cards.scss
+++ b/ui/src/css/components/cards.scss
@@ -39,7 +39,12 @@
   }
 }
 
-.card-title, .card-body {
+.card-title {
+  display: flex;
+  vertical-align: center;
+}
+
+.card-body {
   display: block;
 }
 
@@ -168,7 +173,7 @@
   background-image: linear-gradient(-135deg, #00e1d4 0%, #00c7f2 100%);
 }
 
-.card-test-helpers { --card-icon: url(../images/icons/test-helpers.svg); }
+.card-contracts-cairo { --card-icon: url(../images/icons/contracts-cairo.svg); }
 .card-test-environment { --card-icon: url(../images/icons/test-environment.svg); }
 .card-network-js { --card-icon: url(../images/icons/network-js.svg); }
 .card-gsn-helpers { --card-icon: url(../images/icons/gsn-helpers.svg); }


### PR DESCRIPTION
Replaces the card for Test Helpers in the home page with one for Contracts for Cairo. Also fixes vertical alignment of icons in the cards.