### PR TITLE
Typo causing compilation error

### DIFF
--- a/components/learn/modules/ROOT/pages/developing-smart-contracts.adoc
+++ b/components/learn/modules/ROOT/pages/developing-smart-contracts.adoc
@@ -316,7 +316,7 @@ contract Box is Ownable {
 
     event ValueChanged(uint256 value);
 
-    constuctor() Ownable(msg.sender) {}
+    constructor() Ownable(msg.sender) {}
 
     // The onlyOwner modifier restricts who can call the store function
     function store(uint256 value) public onlyOwner {


### PR DESCRIPTION
Hey OZ doc maintainers,
Typo Solidity example: changed **constuctor** to **constructor** (r letter is missing causing compil error when copy pasting for fast testing). Update developing-smart-contracts.adoc