### PR TITLE
Update polkadot runtime templates reference

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -79,9 +79,9 @@ content:
     - url: https://github.com/OpenZeppelin/nile
       branches: release-v*
       start_path: docs
-    
-    - url: https://github.com/OpenZeppelin/polkadot-generic-runtime-template
-      branches: v1-after-audit # this is a temporary fixed branch, docs will migrate out of this repository and will have proper branches
+
+    - url: https://github.com/OpenZeppelin/polkadot-runtime-templates
+      branches: v2
       start_path: docs
 ui:
   bundle:

--- a/playbook.yml
+++ b/playbook.yml
@@ -81,7 +81,9 @@ content:
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/polkadot-runtime-templates
-      branches: v2
+      branches:
+        - v*
+        - '!v0.1' # initial version not published
       start_path: docs
 ui:
   bundle:


### PR DESCRIPTION
We are about to release v2 of the templates. This PR updates the branch to our release branch and also uses the new repo url(the name was changed, and while redirect works for consistency is better to update it).

**We can merge this PR, but release should happen after the release on the polkadot runtime repo is done.**