### PR TITLE
Cairo: use release branches instead of tags

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -68,12 +68,7 @@ content:
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/cairo-contracts
-      branches: ~
-      tags:
-        - v*
-        - '!v0.7.0-rc.0' # broken antora.yml
-        - '!v0.2.*' # no antora.yml
-        - '!v0.1.0' # no antora.yml
+      branches: release-v*
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/nile

--- a/playbook.yml
+++ b/playbook.yml
@@ -68,7 +68,9 @@ content:
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/cairo-contracts
-      branches: release-v*
+      branches:
+        - release-v*
+        - '!release-v*-rc.*' # exclude release candidates
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/nile

--- a/playbook.yml
+++ b/playbook.yml
@@ -71,6 +71,7 @@ content:
       branches:
         - release-v*
         - '!release-v*-rc.*' # exclude release candidates
+        - '!release-v*-beta.*' # exclude beta releases
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/nile

--- a/playbook.yml
+++ b/playbook.yml
@@ -68,7 +68,8 @@ content:
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/cairo-contracts
-      branches: docs-v*
+      branches:
+        - docs-v*
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/nile

--- a/playbook.yml
+++ b/playbook.yml
@@ -72,7 +72,7 @@ content:
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/nile
-      branches: release-v*
+      branches: release-v0.*
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/polkadot-runtime-templates

--- a/playbook.yml
+++ b/playbook.yml
@@ -72,7 +72,7 @@ content:
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/nile
-      branches: release-v0.*
+      branches: release-v*
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/polkadot-runtime-templates

--- a/playbook.yml
+++ b/playbook.yml
@@ -68,10 +68,7 @@ content:
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/cairo-contracts
-      branches:
-        - release-v*
-        - '!release-v*-rc.*' # exclude release candidates
-        - '!release-v*-beta.*' # exclude beta releases
+      branches: docs-v*
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/nile


### PR DESCRIPTION
This should work out of the box since each release has a release branch.