### PR TITLE
Solidity: Add community-contracts docs

### DIFF
--- a/components/home/modules/ROOT/pages/index.adoc
+++ b/components/home/modules/ROOT/pages/index.adoc
@@ -20,6 +20,11 @@ xref:defender::index.adoc[[.card-title]#Defender# [.card-body]#pass:q[A mission-
 --
 ====
 
+[.card.card-secondary.card-community]
+--
+xref:community-contracts::index.adoc[[.card-title]#Community Contracts# [.card-body]#pass:q[A community-driven extension of our Solidity library.]#]
+--
+
 [.card.card-secondary.card-upgrades]
 --
 xref:upgrades.adoc[[.card-title]#Upgrades# [.card-body]#pass:q[A comprehensive suite of contracts and tooling to deploy and manage upgradeable contracts on Ethereum.]#]

--- a/playbook.yml
+++ b/playbook.yml
@@ -27,6 +27,10 @@ content:
       branches: docs-v*
       start_path: packages/lib/docs
 
+    - url: https://github.com/OpenZeppelin/openzeppelin-community-contracts
+      branches: HEAD
+      start_path: docs
+
     - url: https://github.com/OpenZeppelin/openzeppelin-upgrades
       branches: HEAD
       start_path: docs
@@ -79,7 +83,7 @@ content:
     - url: https://github.com/OpenZeppelin/polkadot-runtime-templates
       branches:
         - v*
-        - '!v0.1' # initial version not published
+        - "!v0.1" # initial version not published
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/rust-contracts-stylus

--- a/ui/preview/model.yml
+++ b/ui/preview/model.yml
@@ -101,8 +101,8 @@ site:
       versions:
       - &latest_version_community_contracts
         url: '#'
-        version: '0.0.0-alpha.0'
-        displayVersion: '0.0.0-alpha.0'
+        version: '0.0.1'
+        displayVersion: '0.0.1'
       latestVersion: *latest_version_community_contracts
     upgrades:
       name: upgrades

--- a/ui/preview/model.yml
+++ b/ui/preview/model.yml
@@ -94,6 +94,16 @@ site:
         version: '2.4'
         displayVersion: '2.3'
       latestVersion: *latest_version_sdk
+    community-contracts:
+      name: community-contracts
+      title: Community Contracts
+      url: '#'
+      versions:
+      - &latest_version_stylus
+        url: '#'
+        version: '0.0.0-alpha.0'
+        displayVersion: '0.0.0-alpha.0'
+      latestVersion: *latest_version_stylus
     upgrades:
       name: upgrades
       title: Upgrades

--- a/ui/preview/model.yml
+++ b/ui/preview/model.yml
@@ -99,11 +99,11 @@ site:
       title: Community Contracts
       url: '#'
       versions:
-      - &latest_version_stylus
+      - &latest_version_community_contracts
         url: '#'
         version: '0.0.0-alpha.0'
         displayVersion: '0.0.0-alpha.0'
-      latestVersion: *latest_version_stylus
+      latestVersion: *latest_version_community_contracts
     upgrades:
       name: upgrades
       title: Upgrades

--- a/ui/src/css/components/cards.scss
+++ b/ui/src/css/components/cards.scss
@@ -168,6 +168,10 @@
   background-image: linear-gradient(-135deg, #00e1d4 0%, #00c7f2 100%);
 }
 
+.card-community {
+  --card-icon: url(../images/icons/community-contracts.svg);
+}
+
 .card-upgrades {
   --card-icon: url(../images/icons/upgrades-plugins.svg);
 }

--- a/ui/theme/images/icons/community-contracts.svg
+++ b/ui/theme/images/icons/community-contracts.svg
@@ -1,0 +1,3 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18.5216 29.4545L10.9714 25.1011V0L18.5216 4.35338V29.4545ZM7.55021 29.4545L0 25.1011V0L7.55021 4.35338V29.4545ZM29.493 29.4545L21.9428 25.1011V0L29.493 4.35338V29.4545Z" fill="#3D3D58"/>
+</svg>

--- a/ui/theme/partials/navigation.hbs
+++ b/ui/theme/partials/navigation.hbs
@@ -20,7 +20,7 @@
     {{/each}}
 
     <h3 class="nav-title">More</h3>
-    {{#each (pick site.components "upgrades-plugins, contracts-cairo, contracts-stylus, substrate-runtimes") }}
+    {{#each (pick site.components "community-contracts, upgrades-plugins, contracts-cairo, contracts-stylus, substrate-runtimes") }}
     {{> navigation-component }}
     {{/each}}
   </div>


### PR DESCRIPTION
### Description

The documentation is public [here](https://community-contracts.netlify.app/community-contracts/0.0.0-alpha.0/index.html) already. With this PR we enable a link in the documentation site while we can keep iterating in the community contracts repository.