### PR TITLE
Support pre-processed community contracts documentation with API Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Finally, add an entry for it inside the [`model.yml`](./ui/preview/model.yml) fi
 
 The contents of each repository under `sources` in `playbook.yml` are used as-is
 with no pre-processing. If the repository requires a pre-processing step, it must
-be done in the CI of that repository and the results pushed to a branch that should
-be then specified as the source in `playbook.yml`.
+be done in the CI of that repository and the results pushed to a branch (e.g., `docs`).
+This branch should then be specified as the source in `playbook.yml` instead of the
+source branch (e.g., `HEAD`).
 
 An example of a CI Github Action that pre-processes the `master` branch and
 pushes the result to the `docs-v*` branch can be found in the OpenZeppelin

--- a/README.md
+++ b/README.md
@@ -16,3 +16,18 @@ To show it in the sidebar, add the `name` from the repo's `antora.yml` in
 inside the [`icons folder`](./ui/theme/images/icons) matching the name.
 
 Finally, add an entry for it inside the [`model.yml`](./ui/preview/model.yml) file, for UI development purposes.
+
+### Post-processing
+
+Generally, each repository under the `sources` field in the `playbook.yml` file
+will use `HEAD` as the default branch. However, if the repository requires to
+execute a post-processing step, a specific branch can be specified.
+
+This site will pull in the latest version of the `branches` field from the
+`playbook.yml` source repository (i.e. `content.sources[*].branches`). This
+can be used to point to a post-processed branch.
+
+An example of a CI Github Action that post-processes the `master` branch and
+pushes the result to the `docs-v*` branch can be found in the OpenZeppelin
+Contracts [docs workflow](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/.github/workflows/docs.yml).
+This workflow creates an automated API reference for the Contracts library.

--- a/README.md
+++ b/README.md
@@ -17,17 +17,14 @@ inside the [`icons folder`](./ui/theme/images/icons) matching the name.
 
 Finally, add an entry for it inside the [`model.yml`](./ui/preview/model.yml) file, for UI development purposes.
 
-### Post-processing
+### Pre-processing
 
-Generally, each repository under the `sources` field in the `playbook.yml` file
-will use `HEAD` as the default branch. However, if the repository requires to
-execute a post-processing step, a specific branch can be specified.
+The contents of each repository under `sources` in `playbook.yml` are used as-is
+with no pre-processing. If the repository requires a pre-processing step, it must
+be done in the CI of that repository and the results pushed to a branch that should
+be then specified as the source in `playbook.yml`.
 
-This site will pull in the latest version of the `branches` field from the
-`playbook.yml` source repository (i.e. `content.sources[*].branches`). This
-can be used to point to a post-processed branch.
-
-An example of a CI Github Action that post-processes the `master` branch and
+An example of a CI Github Action that pre-processes the `master` branch and
 pushes the result to the `docs-v*` branch can be found in the OpenZeppelin
 Contracts [docs workflow](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/.github/workflows/docs.yml).
 This workflow creates an automated API reference for the Contracts library.

--- a/playbook.yml
+++ b/playbook.yml
@@ -28,7 +28,7 @@ content:
       start_path: packages/lib/docs
 
     - url: https://github.com/OpenZeppelin/openzeppelin-community-contracts
-      branches: HEAD
+      branches: docs-v*
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/openzeppelin-upgrades


### PR DESCRIPTION
### Description

Currently, the API reference of the community-contracts repository is not showing up in the official docs: https://docs.openzeppelin.com/community-contracts/0.0.0-alpha.0/

However, it shows up in the Netlify preview: https://community-contracts.netlify.app/

Since the contracts library needs to create an API reference automated from the contracts source, the new code is pushed to a docs branch. This approach was replicated in the community contracts repository.

With this change, the playbook will now point to a post-processed branch