### PR TITLE
Add warning when not on current version of documentation

### DIFF
--- a/ui/src/css/article.scss
+++ b/ui/src/css/article.scss
@@ -270,9 +270,9 @@
 }
 
 .article-banner {
-  background-color: var(--yellow-3);
-  border: solid 1px var(--aluminum-5);
+  background-color: rgb(254 240 138);
+  border: solid 1px rgb(253 224 71);
   border-radius: var(--border-radius);
   padding: 10px;
-  margin: 0 -10px;
+  margin: 1em -10px;
 }

--- a/ui/src/css/article.scss
+++ b/ui/src/css/article.scss
@@ -270,8 +270,8 @@
 }
 
 .article-banner {
-  background-color: var(--aluminum-2);
-  border: solid 1px var(--aluminum-4);
+  background-color: var(--yellow-3);
+  border: solid 1px var(--aluminum-5);
   border-radius: var(--border-radius);
   padding: 10px;
   margin: 0 -10px;

--- a/ui/src/css/globals/_vars.scss
+++ b/ui/src/css/globals/_vars.scss
@@ -26,7 +26,7 @@
   --aluminum-3: #e8e9ea;
   --aluminum-4: #cacbcc;
   --aluminum-5: #989a9b;
-  --yellow-3: #ffc107;
+  --yellow-3: #f2be24;
   --viridian-3: #00b49d;
   --teal-3: #00b5d1;
   --navy-3: #178bea;

--- a/ui/src/css/globals/_vars.scss
+++ b/ui/src/css/globals/_vars.scss
@@ -26,7 +26,7 @@
   --aluminum-3: #e8e9ea;
   --aluminum-4: #cacbcc;
   --aluminum-5: #989a9b;
-  --yellow-3: #f2be24;
+  --yellow-3: #ffc107;
   --viridian-3: #00b49d;
   --teal-3: #00b5d1;
   --navy-3: #178bea;

--- a/ui/theme/partials/article.hbs
+++ b/ui/theme/partials/article.hbs
@@ -10,9 +10,14 @@
 			<b>{{@root.page.component.title}}</b> is deprecated. We are no longer developing new features nor addressing issues. Read <a href="https://forum.openzeppelin.com/t/doubling-down-in-security/2712" target="_blank">here</a> for more info.
 			</div>
 		{{/if}}
-        {{#if page.title}}
-          <h1>{{{page.title}}}</h1>
-        {{/if}}
+		{{#unless (eq @root.page.componentVersion.version @root.page.component.latest.version)}}
+			<div class="article-banner">
+				You are not reading the current version of this documentation. <a href="{{@root.page.component.latest.url}}">{{@root.page.component.latest.version}}</a> is the current version.
+			</div>
+		{{/unless}}
+		{{#if page.title}}
+			<h1>{{{page.title}}}</h1>
+		{{/if}}
 		{{{page.contents}}}
                 <div class="article-navigation">
                 {{#if page.previous}}


### PR DESCRIPTION
Partially addresses #428 

Adds a warning when user is viewing a version of the documentation that is not the latest version (but we'll describe it as "current version" to align with the "Current version" label in the version dropdown.

The current/latest version is the [according to Antora's sorting](https://docs.antora.org/antora/latest/how-component-versions-are-sorted/#latest-version), meaning the most recent version excluding prereleases (unless all versions are prereleases, in which case it'll be the latest prerelease).

Examples:
- For Solidity, the current version is `5.x`. Warn if any other version is used.
![Screenshot 2025-04-04 at 9 27 32 AM](https://github.com/user-attachments/assets/531cb5e4-9004-4fe2-b239-98feac5f6657)

- For Cairo, the current version is `1.0.0`. Warn if any other version is used (even `2.0.0-alpha.0`, since that is a prerelease).
![Screenshot 2025-04-04 at 9 27 51 AM](https://github.com/user-attachments/assets/b3d60e25-6243-4c9a-88b5-b1ca74876127)



