### PR TITLE
Make article banners float

### DIFF
--- a/ui/src/css/article.scss
+++ b/ui/src/css/article.scss
@@ -276,3 +276,9 @@
   padding: 10px;
   margin: 1em -10px;
 }
+
+.floating-banner {
+  position: sticky;
+  top: 10px;
+  z-index: 100;
+}

--- a/ui/theme/partials/article.hbs
+++ b/ui/theme/partials/article.hbs
@@ -1,20 +1,22 @@
 <div class="article-wrapper">
 	<article class="article doc">
-		{{#if (in @root.page.component.name "cli, upgrades")}}
-			<div class="article-banner">
-                          OpenZeppelin SDK is not being actively developed. We recommend using <a href="/upgrades-plugins">Upgrades Plugins</a> instead. For more information, see <a href="https://forum.openzeppelin.com/t/building-for-interoperability-why-we-re-focusing-on-upgrades-plugins/4088" target="_blank">Building for interoperability: why we’re focusing on Upgrades Plugins</a>.
-			</div>
-		{{/if}}
-		{{#if (in @root.page.component.name "network-js, gsn-provider, gsn-helpers, starter-kits")}}
-			<div class="article-banner">
-			<b>{{@root.page.component.title}}</b> is deprecated. We are no longer developing new features nor addressing issues. Read <a href="https://forum.openzeppelin.com/t/doubling-down-in-security/2712" target="_blank">here</a> for more info.
-			</div>
-		{{/if}}
-		{{#unless (eq @root.page.componentVersion.version @root.page.component.latest.version)}}
-			<div class="article-banner">
-				You are not reading the current version of this documentation. <a href="{{@root.page.component.latest.url}}">{{@root.page.component.latest.version}}</a> is the current version.
-			</div>
-		{{/unless}}
+		<div class="floating-banner">
+			{{#if (in @root.page.component.name "cli, upgrades")}}
+				<div class="article-banner">
+					OpenZeppelin SDK is not being actively developed. We recommend using <a href="/upgrades-plugins">Upgrades Plugins</a> instead. For more information, see <a href="https://forum.openzeppelin.com/t/building-for-interoperability-why-we-re-focusing-on-upgrades-plugins/4088" target="_blank">Building for interoperability: why we’re focusing on Upgrades Plugins</a>.
+				</div>
+			{{/if}}
+			{{#if (in @root.page.component.name "network-js, gsn-provider, gsn-helpers, starter-kits")}}
+				<div class="article-banner">
+				<b>{{@root.page.component.title}}</b> is deprecated. We are no longer developing new features nor addressing issues. Read <a href="https://forum.openzeppelin.com/t/doubling-down-in-security/2712" target="_blank">here</a> for more info.
+				</div>
+			{{/if}}
+			{{#unless (eq @root.page.componentVersion.version @root.page.component.latest.version)}}
+				<div class="article-banner">
+					You are not reading the current version of this documentation. <a href="{{@root.page.component.latest.url}}">{{@root.page.component.latest.version}}</a> is the current version.
+				</div>
+			{{/unless}}
+		</div>
 		{{#if page.title}}
 			<h1>{{{page.title}}}</h1>
 		{{/if}}


### PR DESCRIPTION
When user is viewing an outdated version or deprecated content, make the warning banner float so that it is still visible if the user scrolls down.

Addresses comment https://github.com/OpenZeppelin/docs.openzeppelin.com/pull/429#pullrequestreview-2747198302 and related to  https://github.com/OpenZeppelin/docs.openzeppelin.com/issues/428 