### PR TITLE
Draft: Consider using `stable` URL tag, consider removing unsupported versions

### DIFF
--- a/playbook-local-only.yml
+++ b/playbook-local-only.yml
@@ -26,4 +26,4 @@ asciidoc:
     idprefix: ''
 urls:
   redirect_facility: netlify
-  latest_version_segment: latest
+  latest_version_segment: current

--- a/playbook-local-only.yml
+++ b/playbook-local-only.yml
@@ -26,3 +26,4 @@ asciidoc:
     idprefix: ''
 urls:
   redirect_facility: netlify
+  latest_version_segment: latest

--- a/playbook.yml
+++ b/playbook.yml
@@ -20,7 +20,9 @@ content:
       start_path: components/open-source-tools
 
     - url: https://github.com/OpenZeppelin/openzeppelin-contracts
-      branches: docs-v*
+      branches:
+        - docs-v*
+        - "!docs-v2*"
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/openzeppelin-sdk
@@ -78,6 +80,7 @@ content:
     - url: https://github.com/OpenZeppelin/cairo-contracts
       branches:
         - docs-v*
+        - "!docs-v0.*"
       start_path: docs
 
     - url: https://github.com/OpenZeppelin/nile
@@ -87,6 +90,7 @@ content:
     - url: https://github.com/OpenZeppelin/polkadot-runtime-templates
       branches:
         - v*
+        - "!v({1..2})*"
         - "!v0.1" # initial version not published
       start_path: docs
 
@@ -132,4 +136,4 @@ antora:
 urls:
   html_extension_style: drop
   redirect_facility: netlify
-  latest_version_segment: latest
+  latest_version_segment: current

--- a/playbook.yml
+++ b/playbook.yml
@@ -132,3 +132,4 @@ antora:
 urls:
   html_extension_style: drop
   redirect_facility: netlify
+  latest_version_segment: latest

--- a/ui/theme/partials/navigation.hbs
+++ b/ui/theme/partials/navigation.hbs
@@ -33,7 +33,7 @@
       <span class="">{{{./title}}}</span>
       <div class="component-version">
         {{#if (and versions (eq this @root.page.component))}}
-        {{#unless (eq versions.length 1)}}
+        {{#unless (eq @root.page.componentVersion.displayVersion "default")}}
         <button class="flex align-center shrink btn btn-version" id="version-selector">
           {{@root.page.componentVersion.displayVersion}}
         </button>
@@ -47,6 +47,7 @@
                 {{/with}}
               </li>
             </ul>
+            {{#unless (eq versions.length 1)}}
             <p>Other versions</p>
             <ul>
               {{#each versions}}
@@ -57,6 +58,7 @@
               {{/unless}}
               {{/each}}
             </ul>
+            {{/unless}}
           </div>
         </div>
         {{/unless}}


### PR DESCRIPTION
To improve SEO and clarify version usage, this draft PR applies the following ideas for consideration/discussion:
- If the user is on the current version, changes the version in the URL to be `current`.  This will allow the `current` versioned URL to always point to the current version.
  - I haven't seen the `current` tag used in other documentation sites, but our docs UI describes versions as "Current version".
  - We could consider `latest` or `stable` as these are more common, but:
    - `latest` is confusing if there is a newer prerelease than the latest stable version e.g. `2.0.0-alpha.0` vs `1.0.0`
    - `stable` works but in the case of `5.x`, `4.x`, `3.x`, they are technically all stable.
    - Should we consider a combination of `latest` and `stable` (with `stable` having priority)?
- To provide more context due to the URL change above, always show the version number in the left navigation, even if there is only one version, unless the product is unversioned.
  - For example, Upgrades Plugin docs are unversioned, while Uniswap Hooks has one version. 
- Completely removes documentation for versions of products that are no longer supported, since having many old versions (if no one is/should be using the old versions) could be confusing.
  - [ ] Decide if docs for unsupported versions are still useful
  - [ ] Review which versions should be supported for each product
  - Note: For entire products (rather than specific versions) that are deprecated, they are not removed but just unlisted in the navigation as before.  Information in those are still sometimes useful, for example information on how to migrate or conceptual information on topics.

Related to #428 