### PR TITLE
Add tabindex to version <li> tags

### DIFF
--- a/ui/theme/partials/navigation.hbs
+++ b/ui/theme/partials/navigation.hbs
@@ -41,7 +41,7 @@
           <div class="popover">
             <p>Current version</p>
             <ul>
-              <li>
+              <li tabindex="0">
                 {{#with latest}}
                 <a href="{{{url}}}">{{displayVersion}}</a>
                 {{/with}}
@@ -51,7 +51,7 @@
             <ul>
               {{#each versions}}
               {{#unless (eq this ../latest)}}
-              <li>
+              <li tabindex="0">
                 <a href="{{{url}}}">{{displayVersion}}</a>
               </li>
               {{/unless}}


### PR DESCRIPTION
#### Description

Fixes version navigation in Safari