### PR TITLE
feat(defender-sunset): implement Defender sunset documentation changes

### DIFF
--- a/components/home/modules/ROOT/pages/index.adoc
+++ b/components/home/modules/ROOT/pages/index.adoc
@@ -14,9 +14,9 @@ OpenZeppelin provides a complete suite of security products to adopt security be
 xref:contracts::index.adoc[[.card-title]#Contracts# [.card-body]#pass:q[A library of modular, reusable, and secure smart contracts, written in Solidity.]#]
 --
 
-[.card.card-primary.card-defender]
+[.card.card-primary.card-open-source-tools]
 --
-xref:defender::index.adoc[[.card-title]#Defender# [.card-body]#pass:q[A mission-critical developer security platform to code, audit, deploy, monitor, and operate blockchain applications.]#]
+xref:open-source-tools::index.adoc[[.card-title]#Open Source Tools# [.card-body]#pass:q[A collection of tools for blockchain developers including a relayer for transaction submission and a monitoring service for onchain activities.]#]
 --
 
 ====
@@ -66,9 +66,9 @@ xref:confidential-contracts::index.adoc[[.card-title]#Confidential Contracts# [.
 https://github.com/OpenZeppelin/solidity-docgen[[.card-title]#Solidity Docgen# [.card-body]#pass:q[A tool for automatically generating documentation based on the natspec comments of your Solidity contracts.]#]
 --
 
-[.card.card-secondary.card-open-source-tools]
+[.card.card-secondary.card-defender]
 --
-xref:open-source-tools::index.adoc[[.card-title]#Open Source Tools# [.card-body]#pass:q[A collection of tools for blockchain developers including a relayer for transaction submission and a monitoring service for onchain activities.]#]
+xref:defender::index.adoc[[.card-title]#Defender# [.card-body]#pass:q[A mission-critical developer security platform to code, audit, deploy, monitor, and operate blockchain applications.]#]
 --
 
 

--- a/components/home/modules/ROOT/pages/upgrades.adoc
+++ b/components/home/modules/ROOT/pages/upgrades.adoc
@@ -4,7 +4,6 @@ OpenZeppelin provides tooling for deploying and securing upgradeable smart contr
 
 * xref:upgrades-plugins::index.adoc[Upgrades Plugins] to deploy upgradeable contracts with automated security checks.
 * xref:contracts::upgradeable.adoc[Upgradeable Contracts] to build your contract using our Solidity components.
-* xref:defender::module/deploy.adoc[Defender] to manage upgrades in production and automate operations.
 
 Find all of our resources related to upgradeability below.
 
@@ -17,5 +16,4 @@ TIP: If you don't know where to start we suggest to start with xref:learn::upgra
 * xref:contracts:api:proxy.adoc[Proxy Contracts]: A complete list of all available proxy contracts and related utilities, with documentation relevant for low-level use without Upgrades Plugins.
 * https://blog.openzeppelin.com/the-state-of-smart-contract-upgrades[The State of Smart Contract Upgrades]: A survey of upgrade patterns, and good practices and recommendations for upgrades management and governance.
 * xref:contracts:api:proxy.adoc#transparent-vs-uups[Transparent vs UUPS Proxies]: Explaining the differences between the Transparent Proxy Pattern and the newly available UUPS Proxies.
-* https://docs.openzeppelin.com/defender/v2/tutorial/deploy[Deploy an upgrading via Multisig with Defender]: A tutorial on deploying and upgrading a smart contract in production secured by a multisig wallet, using Defender and the Hardhat Upgrades plugin.
 * https://forum.openzeppelin.com/t/uups-proxies-tutorial-solidity-javascript/7786[UUPS Proxies]: A tutorial on using the UUPS proxy pattern: what the Solidity code should look like, and how to use the Upgrades Plugins with this new proxy pattern.

--- a/components/learn/modules/ROOT/pages/sending-gasless-transactions.adoc
+++ b/components/learn/modules/ROOT/pages/sending-gasless-transactions.adoc
@@ -1,6 +1,6 @@
 = Sending gasless transactions
 
-WARNING: This guide is now deprecated, as it uses GSNv1, which is no longer supported. Consider using https://docs.openzeppelin.com/defender/[Defender] for https://blog.openzeppelin.com/gasless-metatransactions-with-openzeppelin-defender/[setting up your own meta-transaction relayers] instead, or using GSNv2 from the https://opengsn.org/[OpenGSN] team for a decentralized solution.
+WARNING: This guide is now deprecated, as it uses GSNv1, which is no longer supported. Consider using GSNv2 from the https://opengsn.org/[OpenGSN] team for a decentralized solution.
 
 WARNING: This article is no longer maintained. Read https://forum.openzeppelin.com/t/doubling-down-in-security/2712[here] for more info.
 
@@ -35,7 +35,7 @@ This may sound strange at first, but paying for user onboarding is a very common
 
 Additionally, you can leverage the GSN in scenarios where your users pay you off-chain in advance (e.g. via credit card), with each GSN-call deducting from their balance on your system. The possibilities are endless!
 
-Furthermore, the GSN is set up in such a way where it’s in the relayers' best interest to serve your requests, and there are measures in place to penalize them if they misbehave. All of this happens automatically, so you can safely start using their services worry-free.
+Furthermore, the GSN is set up in such a way where it's in the relayers' best interest to serve your requests, and there are measures in place to penalize them if they misbehave. All of this happens automatically, so you can safely start using their services worry-free.
 
 TIP: You can learn more about how the GSN works in xref:gsn-provider::interacting-with-relayhub.adoc[Interacting With `RelayHub`].
 

--- a/ui/src/css/components/cards.scss
+++ b/ui/src/css/components/cards.scss
@@ -9,15 +9,17 @@
 
 .card-section-2col .sectionbody,
 .card-section-2col .content {
-  grid-template-columns: repeat(auto-fill, minmax(calc(max(50% - 0.5rem, 250px)), 1fr));
+  grid-template-columns: repeat(
+    auto-fill,
+    minmax(calc(max(50% - 0.5rem, 250px)), 1fr)
+  );
 }
 
-.card-section .sectionbody> :not(.card) {
+.card-section .sectionbody > :not(.card) {
   grid-column: 1 / -1;
 }
 
 .card {
-
   .content,
   .paragraph,
   p {
@@ -59,7 +61,7 @@
   border-radius: var(--border-radius);
   color: inherit;
   text-decoration: none;
-  font-size: .9rem;
+  font-size: 0.9rem;
 
   .card-title {
     font-family: var(--heading);
@@ -74,20 +76,20 @@
 
 .card-learn a {
   border: solid 1px #cacbcc;
-  border-left: solid 3px #53536B;
+  border-left: solid 3px #53536b;
   color: var(--color-text-light);
 
   .card-title {
-    margin-bottom: .8rem;
+    margin-bottom: 0.8rem;
   }
 
   &:hover {
-    border-color: #B8BFF4;
-    border-left-color: #4E5EE4;
+    border-color: #b8bff4;
+    border-left-color: #4e5ee4;
     box-shadow: 0 6px 12px 0 rgba(60, 60, 60, 0.09);
 
     .card-title {
-      color: #4E5EE4;
+      color: #4e5ee4;
     }
   }
 }
@@ -96,11 +98,11 @@
 
 .card-oss a {
   border: solid 1px #cacbcc;
-  border-left: solid 3px #53536B;
+  border-left: solid 3px #53536b;
   color: var(--color-text-light);
 
   .card-title::before {
-    content: "";
+    content: '';
     background-image: var(--card-icon);
     background-repeat: no-repeat;
     background-size: contain;
@@ -108,16 +110,16 @@
     height: 1.2em;
     display: inline-block;
     vertical-align: middle;
-    margin-right: .6rem;
+    margin-right: 0.6rem;
   }
 
   &:hover {
-    border-color: #B8BFF4;
-    border-left-color: #4E5EE4;
+    border-color: #b8bff4;
+    border-left-color: #4e5ee4;
     box-shadow: 0 6px 12px 0 rgba(60, 60, 60, 0.09);
 
     .card-title {
-      color: #4E5EE4;
+      color: #4e5ee4;
     }
   }
 }
@@ -133,7 +135,7 @@
   }
 
   .card-title::before {
-    content: "";
+    content: '';
     background-image: var(--card-icon);
     background-repeat: no-repeat;
     background-size: contain;
@@ -141,7 +143,7 @@
     height: 1.2em;
     display: inline-block;
     vertical-align: middle;
-    margin-right: .6em;
+    margin-right: 0.6em;
   }
 }
 
@@ -165,19 +167,19 @@
     position: absolute;
     bottom: 30px;
     right: -20px;
-    content: "";
+    content: '';
     background-image: url(../images/cards.svg);
     background-repeat: no-repeat;
     background-size: contain;
   }
 
   &::after {
-    content: "Get started >";
+    content: 'Get started >';
     font-family: var(--heading);
     font-weight: var(--weight-bold);
-    font-size: .8em;
+    font-size: 0.8em;
     text-transform: uppercase;
-    letter-spacing: .05em;
+    letter-spacing: 0.05em;
   }
 }
 
@@ -195,9 +197,18 @@
   background-image: linear-gradient(45deg, #6746d6 0%, #a134d1 100%);
 }
 
-.card-defender a {
-  --card-icon: url(../images/defender_white.svg);
+.card-open-source-tools a {
+  --card-icon: url(../images/icons/open-source-tools.svg);
   background-image: linear-gradient(-135deg, #00e1d4 0%, #00c7f2 100%);
+
+  /* Custom adjustments for the open source tools icon as it's different from the other icons */
+  .card-title::before {
+    filter: brightness(0) invert(1);
+    height: 1.8em;
+    width: 1.8em;
+    margin-top: -7px;
+    margin-right: 0.4em;
+  }
 }
 
 .card-community {
@@ -206,6 +217,10 @@
 
 .card-confidential {
   --card-icon: url(../images/icons/confidential-contracts.svg);
+}
+
+.card-defender {
+  --card-icon: url(../images/icons/defender.svg);
 }
 
 .card-upgrades {

--- a/ui/theme/partials/header.hbs
+++ b/ui/theme/partials/header.hbs
@@ -41,7 +41,6 @@
       <a class="navbar-item" href="https://forum.openzeppelin.com">Forum</a>
       <a class="navbar-item" href="https://blog.openzeppelin.com">Blog</a>
       <a class="navbar-item" href="https://openzeppelin.com">Website</a>
-      <a class="navbar-button" href="https://defender.openzeppelin.com/v2/#/auth/sign-up">Defender Free Trial</a>
     </div>
   </nav>
 </header>

--- a/ui/theme/partials/navigation.hbs
+++ b/ui/theme/partials/navigation.hbs
@@ -15,12 +15,13 @@
     {{/each}}
 
     <h3 class="nav-title">Our Products</h3>
-    {{#each (pick site.components "defender, contracts, open-source-tools")}}
+    {{#each (pick site.components "contracts, open-source-tools")}}
     {{> navigation-component }}
     {{/each}}
 
     <h3 class="nav-title">More</h3>
-    {{#each (pick site.components "community-contracts, upgrades-plugins, contracts-cairo, contracts-stylus, substrate-runtimes, stellar-contracts, uniswap-hooks, confidential-contracts") }}
+    {{#each (pick site.components "community-contracts, upgrades-plugins, contracts-cairo, contracts-stylus,
+    substrate-runtimes, stellar-contracts, uniswap-hooks, confidential-contracts, defender") }}
     {{> navigation-component }}
     {{/each}}
   </div>


### PR DESCRIPTION
Implements all requirements from Linear ticket PLAT-6762 to sunset Defender across documentation:

- Remove Defender Free Trial button from header navigation
- Move Defender from "Our Products" to bottom of "More" section in sidebar
- Replace Defender primary feature card with Open Source Tools
- Downgrade Defender to secondary card with standard styling
- Remove Defender mentions from Upgrades page
- Remove Defender CTAs from gasless transactions guide