### PR TITLE
Update Consensys links

### DIFF
--- a/components/learn/modules/ROOT/pages/developing-smart-contracts.adoc
+++ b/components/learn/modules/ROOT/pages/developing-smart-contracts.adoc
@@ -13,7 +13,7 @@ We won't cover language concepts such as syntax or keywords in this guide. For t
 
  * For a general overview of how Ethereum and smart contracts work, the official website hosts a https://ethereum.org/learn/[Learn about Ethereum] section with lots of beginner-friendly content.
  * If you're new to the language, the https://solidity.readthedocs.io/en/latest/introduction-to-smart-contracts.html[official Solidity documentation] is a good resource to have handy. Take a look at their https://solidity.readthedocs.io/en/latest/security-considerations.html[security recommendations], which nicely go over the differences between blockchains and traditional software platforms.
- * Consensys' https://consensys.github.io/smart-contract-best-practices/[best practices] are quite extensive, and include both https://consensys.github.io/smart-contract-best-practices/development-recommendations/[proven patterns] to learn from and https://consensys.github.io/smart-contract-best-practices/attacks/[known pitfalls] to avoid.
+ * Consensys' https://consensysdiligence.github.io/smart-contract-best-practices/[best practices] are quite extensive, and include both https://consensysdiligence.github.io/smart-contract-best-practices/development-recommendations/[proven patterns] to learn from and https://consensysdiligence.github.io/smart-contract-best-practices/attacks/[known pitfalls] to avoid.
  * The https://ethernaut.openzeppelin.com/[Ethernaut] web-based game will have you look for subtle vulnerabilities in smart contracts as you advance through levels of increasing difficulty.
 
 With that out of the way, let's get started!

--- a/components/learn/modules/ROOT/pages/preparing-for-mainnet.adoc
+++ b/components/learn/modules/ROOT/pages/preparing-for-mainnet.adoc
@@ -18,7 +18,7 @@ While security affects all of software development, security in smart contracts 
 
 With this in mind, security should be a primary concern at all stages of development. This means that **security is not something that you sprinkle on your project a week before you release**, but a guiding principle starting day one of your project.
 
-Review https://consensys.github.io/smart-contract-best-practices/[smart contract security best practices] as you begin coding, join the https://forum.openzeppelin.com/c/security/25[security discussions in our forum], and make sure to go through our https://blog.openzeppelin.com/follow-this-quality-checklist-before-an-audit-8cc6a0e44845/[quality checklist] to ensure your project is healthy.
+Review https://consensysdiligence.github.io/smart-contract-best-practices/[smart contract security best practices] as you begin coding, join the https://forum.openzeppelin.com/c/security/25[security discussions in our forum], and make sure to go through our https://blog.openzeppelin.com/follow-this-quality-checklist-before-an-audit-8cc6a0e44845/[quality checklist] to ensure your project is healthy.
 
 Once you are done, it's a good time to request an audit with one or more auditing firms. You can https://openzeppelin.com/security-audits/[request an audit] from the OpenZeppelin Research Team - we are an experienced team with a https://blog.openzeppelin.com/security-audits/[long track record].
 


### PR DESCRIPTION
# Update Consensys Links

The [Preparing for Mainnet](https://github.com/OpenZeppelin/docs.openzeppelin.com/blob/master/components/learn/modules/ROOT/pages/preparing-for-mainnet.adoc) and [Developing Smart Contracts](https://github.com/OpenZeppelin/docs.openzeppelin.com/blob/master/components/learn/modules/ROOT/pages/developing-smart-contracts.adoc) pages use [consensys.github.io](consensys.github.io) which was moved to [consenysdiligence.github.io](consesnysdiligence.github.io). 

This PR solves the 404 errors on the following links that match that criteria in `Developing Smart Contracts`
- [best practices](https://consensysdiligence.github.io/smart-contract-best-practices/)
- [proven patterns](https://consensysdiligence.github.io/smart-contract-best-practices/development-recommendations/)
- [known pitfalls](https://consensysdiligence.github.io/smart-contract-best-practices/attacks/)

and one in `Preparing for Mainnet`
- [smart contract security best practices](https://consensysdiligence.github.io/smart-contract-best-practices/) 

